### PR TITLE
feat: migrate module to protomcp.org/nanorpc

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,0 +1,1 @@
+../internal/build/cspell.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-  "cSpell.language": "en-GB",
-  "cSpell.configFile": "${workspaceFolder}/internal/build/cspell.json"
+  "cSpell.language": "en-GB"
 }

--- a/AGENT.md
+++ b/AGENT.md
@@ -61,7 +61,7 @@ make generate
 
 The project uses a sophisticated build system that handles multiple Go modules:
 
-- **Root module**: `github.com/amery/nanorpc`
+- **Root module**: `protomcp.org/nanorpc`
 - **Submodules**: `pkg/generator`, `pkg/nanopb`, `pkg/nanorpc`
 - **Dynamic rules**: Generated via `internal/build/gen_mk.sh`
 - **Dependency tracking**: Handles inter-module dependencies

--- a/README.md
+++ b/README.md
@@ -106,6 +106,6 @@ make build
 - <https://github.com/nanopb/nanopb>
 - <https://github.com/amery/protogen>
 
-[codecov-badge]: https://codecov.io/gh/amery/nanorpc/branch/main/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/amery/nanorpc
+[codecov-badge]: https://codecov.io/gh/protomcp/nanorpc/branch/main/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/protomcp/nanorpc
 [nanopb-url]: https://github.com/nanopb/nanopb

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
-module github.com/amery/nanorpc
+module protomcp.org/nanorpc
 
 go 1.23.0
 
 replace (
-	github.com/amery/nanorpc/pkg/generator => ./pkg/generator
-	github.com/amery/nanorpc/pkg/nanopb => ./pkg/nanopb
-	github.com/amery/nanorpc/pkg/nanorpc => ./pkg/nanorpc
+	protomcp.org/nanorpc/pkg/generator => ./pkg/generator
+	protomcp.org/nanorpc/pkg/nanopb => ./pkg/nanopb
+	protomcp.org/nanorpc/pkg/nanorpc => ./pkg/nanorpc
 )

--- a/internal/build/cspell.json
+++ b/internal/build/cspell.json
@@ -28,6 +28,8 @@
     "protodelim",
     "protogen",
     "protoimpl",
+    "PROTOMCP",
+    "protomcp",
     "protoreflect",
     "protos",
     "protowire",

--- a/pkg/generator/go.mod
+++ b/pkg/generator/go.mod
@@ -1,4 +1,4 @@
-module github.com/amery/nanorpc/pkg/generator
+module protomcp.org/nanorpc/pkg/generator
 
 go 1.23.0
 

--- a/pkg/nanopb/go.mod
+++ b/pkg/nanopb/go.mod
@@ -1,3 +1,3 @@
-module github.com/amery/nanorpc/pkg/nanopb
+module protomcp.org/nanorpc/pkg/nanopb
 
 go 1.23.0

--- a/pkg/nanorpc/README.md
+++ b/pkg/nanorpc/README.md
@@ -22,7 +22,7 @@ see the companion `server` package.
 ## Installation
 
 ```bash
-go get github.com/amery/nanorpc/pkg/nanorpc
+go get protomcp.org/nanorpc/pkg/nanorpc
 ```
 
 ## Quick Start
@@ -38,7 +38,7 @@ import (
 
     "darvaza.org/slog"
 
-    "github.com/amery/nanorpc/pkg/nanorpc"
+    "protomcp.org/nanorpc/pkg/nanorpc"
 )
 
 func main() {
@@ -252,9 +252,9 @@ for i := 0; i < 10; i++ {
 wg.Wait()
 ```
 
-[godoc-badge]: https://pkg.go.dev/badge/github.com/amery/nanorpc/pkg/nanorpc.svg
-[godoc-url]: https://pkg.go.dev/github.com/amery/nanorpc/pkg/nanorpc
-[goreportcard-badge]: https://goreportcard.com/badge/github.com/amery/nanorpc/pkg/nanorpc
-[goreportcard-url]: https://goreportcard.com/report/github.com/amery/nanorpc/pkg/nanorpc
-[codecov-badge]: https://codecov.io/gh/amery/nanorpc/branch/main/graph/badge.svg?flag=nanorpc
-[codecov-url]: https://codecov.io/gh/amery/nanorpc?flag=nanorpc
+[godoc-badge]: https://pkg.go.dev/badge/protomcp.org/nanorpc/pkg/nanorpc.svg
+[godoc-url]: https://pkg.go.dev/protomcp.org/nanorpc/pkg/nanorpc
+[goreportcard-badge]: https://goreportcard.com/badge/protomcp.org/nanorpc/pkg/nanorpc
+[goreportcard-url]: https://goreportcard.com/report/protomcp.org/nanorpc/pkg/nanorpc
+[codecov-badge]: https://codecov.io/gh/protomcp/nanorpc/branch/main/graph/badge.svg?flag=nanorpc
+[codecov-url]: https://codecov.io/gh/protomcp/nanorpc?flag=nanorpc

--- a/pkg/nanorpc/client/README.md
+++ b/pkg/nanorpc/client/README.md
@@ -17,7 +17,7 @@ The NanoRPC client features:
 ## Basic Usage
 
 ```go
-import "github.com/amery/nanorpc/pkg/nanorpc/client"
+import "protomcp.org/nanorpc/pkg/nanorpc/client"
 
 // Create a simple client
 c, err := client.NewClient(context.Background(), "localhost:8080")
@@ -157,8 +157,8 @@ The package includes test utilities for writing unit tests:
 
 ```go
 import (
-    "github.com/amery/nanorpc/pkg/nanorpc/client"
-    "github.com/amery/nanorpc/pkg/nanorpc/common/testutils"
+    "protomcp.org/nanorpc/pkg/nanorpc/client"
+    "protomcp.org/nanorpc/pkg/nanorpc/common/testutils"
 )
 
 func TestMyClient(t *testing.T) {

--- a/pkg/nanorpc/client/client.go
+++ b/pkg/nanorpc/client/client.go
@@ -10,8 +10,8 @@ import (
 	"darvaza.org/slog"
 	"darvaza.org/x/net/reconnect"
 
-	"github.com/amery/nanorpc/pkg/nanorpc"
-	"github.com/amery/nanorpc/pkg/nanorpc/common"
+	"protomcp.org/nanorpc/pkg/nanorpc"
+	"protomcp.org/nanorpc/pkg/nanorpc/common"
 )
 
 // Client is a reconnecting NanoRPC client.

--- a/pkg/nanorpc/client/config.go
+++ b/pkg/nanorpc/client/config.go
@@ -11,7 +11,7 @@ import (
 	"darvaza.org/x/config"
 	"darvaza.org/x/net/reconnect"
 
-	"github.com/amery/nanorpc/pkg/nanorpc"
+	"protomcp.org/nanorpc/pkg/nanorpc"
 )
 
 // hashCache is the default hash cache for the client package.

--- a/pkg/nanorpc/client/config_test.go
+++ b/pkg/nanorpc/client/config_test.go
@@ -8,8 +8,8 @@ import (
 	"darvaza.org/slog/handlers/discard"
 	"darvaza.org/x/net/reconnect"
 
-	"github.com/amery/nanorpc/pkg/nanorpc"
-	"github.com/amery/nanorpc/pkg/nanorpc/common/testutils"
+	"protomcp.org/nanorpc/pkg/nanorpc"
+	"protomcp.org/nanorpc/pkg/nanorpc/common/testutils"
 )
 
 // ClientConfigTestCase represents a test case for client configuration

--- a/pkg/nanorpc/client/logger.go
+++ b/pkg/nanorpc/client/logger.go
@@ -6,7 +6,7 @@ import (
 	"darvaza.org/slog"
 	"darvaza.org/slog/handlers/discard"
 
-	"github.com/amery/nanorpc/pkg/nanorpc/common"
+	"protomcp.org/nanorpc/pkg/nanorpc/common"
 )
 
 // getLogger returns the base logger for the client, creating one if needed

--- a/pkg/nanorpc/client/logger_test.go
+++ b/pkg/nanorpc/client/logger_test.go
@@ -7,7 +7,7 @@ import (
 	"darvaza.org/core"
 	"darvaza.org/slog"
 
-	"github.com/amery/nanorpc/pkg/nanorpc/common/testutils"
+	"protomcp.org/nanorpc/pkg/nanorpc/common/testutils"
 )
 
 // mockAddr implements net.Addr for testing

--- a/pkg/nanorpc/client/request.go
+++ b/pkg/nanorpc/client/request.go
@@ -6,8 +6,8 @@ import (
 	"darvaza.org/core"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/amery/nanorpc/pkg/nanorpc"
-	"github.com/amery/nanorpc/pkg/nanorpc/common"
+	"protomcp.org/nanorpc/pkg/nanorpc"
+	"protomcp.org/nanorpc/pkg/nanorpc/common"
 )
 
 // SubscribeCallback is a function given to [Subscribe] to be called on every update

--- a/pkg/nanorpc/client/request_counter_test.go
+++ b/pkg/nanorpc/client/request_counter_test.go
@@ -3,7 +3,7 @@ package client
 import (
 	"testing"
 
-	"github.com/amery/nanorpc/pkg/nanorpc/common/testutils"
+	"protomcp.org/nanorpc/pkg/nanorpc/common/testutils"
 )
 
 // testBasicCounter tests basic counter functionality

--- a/pkg/nanorpc/client/request_test.go
+++ b/pkg/nanorpc/client/request_test.go
@@ -3,8 +3,8 @@ package client
 import (
 	"testing"
 
-	"github.com/amery/nanorpc/pkg/nanorpc"
-	"github.com/amery/nanorpc/pkg/nanorpc/common/testutils"
+	"protomcp.org/nanorpc/pkg/nanorpc"
+	"protomcp.org/nanorpc/pkg/nanorpc/common/testutils"
 )
 
 type requestTypeTestCase struct {

--- a/pkg/nanorpc/client/session.go
+++ b/pkg/nanorpc/client/session.go
@@ -12,8 +12,8 @@ import (
 	"darvaza.org/x/net/reconnect"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/amery/nanorpc/pkg/nanorpc"
-	"github.com/amery/nanorpc/pkg/nanorpc/common"
+	"protomcp.org/nanorpc/pkg/nanorpc"
+	"protomcp.org/nanorpc/pkg/nanorpc/common"
 )
 
 // clientRequest combines in a single object the fields needed for

--- a/pkg/nanorpc/common/fields_test.go
+++ b/pkg/nanorpc/common/fields_test.go
@@ -6,7 +6,7 @@ import (
 
 	"darvaza.org/slog"
 
-	"github.com/amery/nanorpc/pkg/nanorpc/common/testutils"
+	"protomcp.org/nanorpc/pkg/nanorpc/common/testutils"
 )
 
 // mockAddr implements net.Addr for testing

--- a/pkg/nanorpc/doc.go
+++ b/pkg/nanorpc/doc.go
@@ -8,6 +8,6 @@
 //   - Error handling utilities
 //
 // The actual client and server implementations are in separate packages:
-//   - Client: github.com/amery/nanorpc/pkg/nanorpc/client
-//   - Server: github.com/amery/nanorpc/pkg/nanorpc/server
+//   - Client: protomcp.org/nanorpc/pkg/nanorpc/client
+//   - Server: protomcp.org/nanorpc/pkg/nanorpc/server
 package nanorpc

--- a/pkg/nanorpc/go.mod
+++ b/pkg/nanorpc/go.mod
@@ -1,4 +1,4 @@
-module github.com/amery/nanorpc/pkg/nanorpc
+module protomcp.org/nanorpc/pkg/nanorpc
 
 go 1.23.0
 
@@ -11,7 +11,7 @@ require (
 	darvaza.org/x/net v0.4.0
 	darvaza.org/x/sync v0.3.0
 	github.com/amery/defaults v0.1.0 // indirect
-	github.com/amery/nanorpc/pkg/nanopb v0.1.0
+	protomcp.org/nanorpc/pkg/nanopb v0.1.0
 )
 
 require google.golang.org/protobuf v1.35.2
@@ -29,4 +29,4 @@ require (
 	golang.org/x/text v0.27.0 // indirect
 )
 
-replace github.com/amery/nanorpc/pkg/nanopb => ../nanopb
+replace protomcp.org/nanorpc/pkg/nanopb => ../nanopb

--- a/pkg/nanorpc/nanorpc.pb.go
+++ b/pkg/nanorpc/nanorpc.pb.go
@@ -7,9 +7,9 @@
 package nanorpc
 
 import (
-	_ "github.com/amery/nanorpc/pkg/nanopb"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	_ "protomcp.org/nanorpc/pkg/nanopb"
 	reflect "reflect"
 	sync "sync"
 )

--- a/pkg/nanorpc/server/README.md
+++ b/pkg/nanorpc/server/README.md
@@ -44,7 +44,7 @@ responsibilities:
 ## Installation
 
 ```bash
-go get github.com/amery/nanorpc/pkg/nanorpc/server
+go get protomcp.org/nanorpc/pkg/nanorpc/server
 ```
 
 ## Quick Start
@@ -59,7 +59,7 @@ import (
     "log"
     "net"
 
-    "github.com/amery/nanorpc/pkg/nanorpc/server"
+    "protomcp.org/nanorpc/pkg/nanorpc/server"
 )
 
 func main() {
@@ -92,7 +92,7 @@ import (
     "log"
     "net"
 
-    "github.com/amery/nanorpc/pkg/nanorpc/server"
+    "protomcp.org/nanorpc/pkg/nanorpc/server"
 )
 
 func main() {
@@ -129,7 +129,7 @@ import (
     "net"
     "time"
 
-    "github.com/amery/nanorpc/pkg/nanorpc/server"
+    "protomcp.org/nanorpc/pkg/nanorpc/server"
 )
 
 func main() {
@@ -241,7 +241,7 @@ The package includes comprehensive testing utilities:
 Run individual component tests:
 
 ```bash
-go test -v github.com/amery/nanorpc/pkg/nanorpc/server
+go test -v protomcp.org/nanorpc/pkg/nanorpc/server
 ```
 
 ### Integration Tests
@@ -302,9 +302,9 @@ The decoupled architecture enables easy extension for:
 - **Rate Limiting**: Per-session or global rate controls
 - **Metrics Collection**: Connection and request monitoring
 
-[godoc-badge]: https://pkg.go.dev/badge/github.com/amery/nanorpc/pkg/nanorpc/server.svg
-[godoc-url]: https://pkg.go.dev/github.com/amery/nanorpc/pkg/nanorpc/server
-[goreportcard-badge]: https://goreportcard.com/badge/github.com/amery/nanorpc/pkg/nanorpc/server
-[goreportcard-url]: https://goreportcard.com/report/github.com/amery/nanorpc/pkg/nanorpc/server
-[codecov-badge]: https://codecov.io/gh/amery/nanorpc/branch/main/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/amery/nanorpc
+[godoc-badge]: https://pkg.go.dev/badge/protomcp.org/nanorpc/pkg/nanorpc/server.svg
+[godoc-url]: https://pkg.go.dev/protomcp.org/nanorpc/pkg/nanorpc/server
+[goreportcard-badge]: https://goreportcard.com/badge/protomcp.org/nanorpc/pkg/nanorpc/server
+[goreportcard-url]: https://goreportcard.com/report/protomcp.org/nanorpc/pkg/nanorpc/server
+[codecov-badge]: https://codecov.io/gh/protomcp/nanorpc/branch/main/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/protomcp/nanorpc

--- a/pkg/nanorpc/server/example_handlers_test.go
+++ b/pkg/nanorpc/server/example_handlers_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/amery/nanorpc/pkg/nanorpc"
-	"github.com/amery/nanorpc/pkg/nanorpc/server"
+	"protomcp.org/nanorpc/pkg/nanorpc"
+	"protomcp.org/nanorpc/pkg/nanorpc/server"
 )
 
 // Example_jsonEchoHandler demonstrates using JSON helpers for request/response handling

--- a/pkg/nanorpc/server/handler.go
+++ b/pkg/nanorpc/server/handler.go
@@ -6,7 +6,7 @@ import (
 
 	"darvaza.org/core"
 
-	"github.com/amery/nanorpc/pkg/nanorpc"
+	"protomcp.org/nanorpc/pkg/nanorpc"
 )
 
 // RequestContext provides request information and response utilities

--- a/pkg/nanorpc/server/handler_request_test.go
+++ b/pkg/nanorpc/server/handler_request_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/amery/nanorpc/pkg/nanorpc"
+	"protomcp.org/nanorpc/pkg/nanorpc"
 )
 
 const (

--- a/pkg/nanorpc/server/handler_test.go
+++ b/pkg/nanorpc/server/handler_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/amery/nanorpc/pkg/nanorpc"
-	"github.com/amery/nanorpc/pkg/nanorpc/common/testutils"
+	"protomcp.org/nanorpc/pkg/nanorpc"
+	"protomcp.org/nanorpc/pkg/nanorpc/common/testutils"
 )
 
 // Test helpers and factories

--- a/pkg/nanorpc/server/interfaces.go
+++ b/pkg/nanorpc/server/interfaces.go
@@ -6,7 +6,7 @@ import (
 
 	"darvaza.org/core"
 
-	"github.com/amery/nanorpc/pkg/nanorpc"
+	"protomcp.org/nanorpc/pkg/nanorpc"
 )
 
 // Listener handles connection acceptance

--- a/pkg/nanorpc/server/logger.go
+++ b/pkg/nanorpc/server/logger.go
@@ -5,7 +5,7 @@ import (
 
 	"darvaza.org/slog"
 
-	"github.com/amery/nanorpc/pkg/nanorpc/common"
+	"protomcp.org/nanorpc/pkg/nanorpc/common"
 )
 
 // Server logging methods

--- a/pkg/nanorpc/server/logger_test.go
+++ b/pkg/nanorpc/server/logger_test.go
@@ -6,8 +6,8 @@ import (
 
 	"darvaza.org/slog"
 
-	"github.com/amery/nanorpc/pkg/nanorpc/common"
-	"github.com/amery/nanorpc/pkg/nanorpc/common/testutils"
+	"protomcp.org/nanorpc/pkg/nanorpc/common"
+	"protomcp.org/nanorpc/pkg/nanorpc/common/testutils"
 )
 
 // Test server default logger

--- a/pkg/nanorpc/server/request_context.go
+++ b/pkg/nanorpc/server/request_context.go
@@ -7,7 +7,7 @@ import (
 	"darvaza.org/core"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/amery/nanorpc/pkg/nanorpc"
+	"protomcp.org/nanorpc/pkg/nanorpc"
 )
 
 // SendOK sends a successful response with optional data

--- a/pkg/nanorpc/server/request_context_test.go
+++ b/pkg/nanorpc/server/request_context_test.go
@@ -7,7 +7,7 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
-	"github.com/amery/nanorpc/pkg/nanorpc"
+	"protomcp.org/nanorpc/pkg/nanorpc"
 )
 
 // testData is a test struct for JSON marshaling tests

--- a/pkg/nanorpc/server/server.go
+++ b/pkg/nanorpc/server/server.go
@@ -10,7 +10,7 @@ import (
 	"darvaza.org/slog/handlers/discard"
 	"darvaza.org/x/sync/workgroup"
 
-	"github.com/amery/nanorpc/pkg/nanorpc/common"
+	"protomcp.org/nanorpc/pkg/nanorpc/common"
 )
 
 // Server represents a decoupled NanoRPC server

--- a/pkg/nanorpc/server/server_test.go
+++ b/pkg/nanorpc/server/server_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/amery/nanorpc/pkg/nanorpc"
+	"protomcp.org/nanorpc/pkg/nanorpc"
 )
 
 func TestDecoupledServer_PingPong(t *testing.T) {

--- a/pkg/nanorpc/server/session.go
+++ b/pkg/nanorpc/server/session.go
@@ -13,9 +13,9 @@ import (
 	"darvaza.org/slog"
 	"darvaza.org/slog/handlers/discard"
 
-	"github.com/amery/nanorpc/pkg/nanorpc/common"
+	"protomcp.org/nanorpc/pkg/nanorpc/common"
 
-	"github.com/amery/nanorpc/pkg/nanorpc"
+	"protomcp.org/nanorpc/pkg/nanorpc"
 )
 
 // DefaultSession implements Session interface

--- a/pkg/nanorpc/server/session_manager.go
+++ b/pkg/nanorpc/server/session_manager.go
@@ -8,7 +8,7 @@ import (
 	"darvaza.org/slog"
 	"darvaza.org/slog/handlers/discard"
 
-	"github.com/amery/nanorpc/pkg/nanorpc/common"
+	"protomcp.org/nanorpc/pkg/nanorpc/common"
 )
 
 // DefaultSessionManager implements SessionManager interface

--- a/pkg/nanorpc/server/session_test.go
+++ b/pkg/nanorpc/server/session_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/amery/nanorpc/pkg/nanorpc"
+	"protomcp.org/nanorpc/pkg/nanorpc"
 )
 
 func TestDefaultSession_ID(t *testing.T) {


### PR DESCRIPTION
### **User description**
## Summary

Implements the module migration plan from issue #25 to move the repository from `github.com/amery/nanorpc` to the protomcp organization with canonical vanity imports at `protomcp.org/nanorpc`.

### Changes Made

- Updated module declaration in all go.mod files to `protomcp.org/nanorpc`
- Updated all import statements across Go source files (39 files total)
- Updated documentation references in README.md, AGENT.md, and package docs
- Updated codecov badges to point to protomcp organization
- Added protomcp terms to cspell dictionary

### Verification

- All tests pass with new import paths
- `make tidy` succeeds with no issues
- Module dependencies properly resolved

### Next Steps

After this PR is merged:
1. The old `github.com/amery/nanorpc` repository can be forked back with deprecation notice
2. Vanity import configuration at protomcp.org/nanorpc
3. Begin subscription system implementation per SUBSCRIPTION_DESIGN.md

Related to #25


___

### **PR Type**
Other


___

### **Description**
- Migrate module from `github.com/amery/nanorpc` to `protomcp.org/nanorpc`

- Update all import paths across 39 Go files

- Update documentation and badge references

- Fix VSCode cspell configuration with symlink


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["github.com/amery/nanorpc"] -- "module migration" --> B["protomcp.org/nanorpc"]
  B --> C["Update imports"]
  B --> D["Update documentation"]
  B --> E["Update badges"]
  F[".vscode/settings.json"] -- "fix cspell config" --> G[".vscode/cspell.json symlink"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation, README files, and badges to reference the new module path and URLs using the "protomcp.org/nanorpc" domain.
  * Updated example code snippets and installation instructions to use the new import paths.

* **Chores**
  * Changed Go module paths and dependency references throughout the project to "protomcp.org/nanorpc".
  * Updated spell checker configurations to recognize "PROTOMCP" and "protomcp" as valid terms.
  * Adjusted VS Code settings to reference the new spell checker configuration location.

* **Style**
  * No user-facing style changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->