### PR TITLE
feat(nanorpc): update to use nanopb v0.2.0 from registry

### DIFF
--- a/pkg/nanorpc/go.mod
+++ b/pkg/nanorpc/go.mod
@@ -11,7 +11,7 @@ require (
 	darvaza.org/x/net v0.4.0
 	darvaza.org/x/sync v0.3.0
 	github.com/amery/defaults v0.1.0 // indirect
-	protomcp.org/nanorpc/pkg/nanopb v0.1.0
+	protomcp.org/nanorpc/pkg/nanopb v0.2.0
 )
 
 require google.golang.org/protobuf v1.35.2
@@ -28,5 +28,3 @@ require (
 	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/text v0.27.0 // indirect
 )
-
-replace protomcp.org/nanorpc/pkg/nanopb => ../nanopb

--- a/pkg/nanorpc/go.sum
+++ b/pkg/nanorpc/go.sum
@@ -50,3 +50,5 @@ google.golang.org/protobuf v1.35.2 h1:8Ar7bF+apOIoThw1EdZl0p1oWvMqTHmpA2fRTyZO8i
 google.golang.org/protobuf v1.35.2/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+protomcp.org/nanorpc/pkg/nanopb v0.2.0 h1:X7NTgbz7qGijCX1nM7gch0kQdh2IRI8qzrM8BifRQkY=
+protomcp.org/nanorpc/pkg/nanopb v0.2.0/go.mod h1:WLXmyi8J23fYRkLjGnHlJW025tORg9Qu1C8d8E+hFlo=


### PR DESCRIPTION
## Summary

Updates nanorpc to use the published nanopb v0.2.0 release from the Go module registry instead of the local replace directive.

### Changes Made

- Updated `pkg/nanorpc/go.mod` to use `protomcp.org/nanorpc/pkg/nanopb v0.2.0`
- Removed local replace directive that was pointing to `../nanopb`
- Created and published nanopb v0.2.0 release tag

### Verification

- All tests pass with the new nanopb version from registry
- Module downloads successfully from `proxy.golang.org`
- `make test-nanorpc` confirms compatibility

### Benefits

- Uses proper semantic versioning for nanopb dependency
- Enables independent development and release cycles
- Follows Go module best practices for multi-module repositories

Related to #25