### PR TITLE
refactor(tests): comprehensive assertion hygiene standardisation

### DIFF
--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -28,14 +28,14 @@ func (tc newGeneratorTestCase) Test(t *testing.T) {
 	gen, err := NewGenerator(tc.plugin)
 
 	if tc.wantErr {
-		core.AssertError(t, err, "expected error")
-		core.AssertNil(t, gen, "expected nil generator")
+		core.AssertError(t, err, "error")
+		core.AssertNil(t, gen, "generator")
 		return
 	}
 
 	core.AssertNoError(t, err, "unexpected error")
-	core.AssertNotNil(t, gen, "expected non-nil generator")
-	core.AssertEqual(t, tc.plugin, gen.p, "plugin mismatch")
+	core.AssertNotNil(t, gen, "generator")
+	core.AssertEqual(t, tc.plugin, gen.p, "plugin")
 	core.AssertNil(t, gen.t, "template should be nil initially")
 }
 
@@ -80,7 +80,7 @@ func (tc withTemplatesTestCase) Test(t *testing.T) {
 	// Skip actual filesystem operation and just check the error condition
 	if gen.t != nil {
 		// Generator already has templates
-		core.AssertTrue(t, tc.wantErr, "expected error for generator with existing templates")
+		core.AssertTrue(t, tc.wantErr, "generator error")
 		return
 	}
 

--- a/pkg/nanorpc/client/config_test.go
+++ b/pkg/nanorpc/client/config_test.go
@@ -30,13 +30,13 @@ func (tc ClientConfigTestCase) Name() string {
 func (tc ClientConfigTestCase) Test(t *testing.T) {
 	t.Helper()
 	err := tc.config.SetDefaults()
-	core.AssertNoError(t, err, "SetDefaults failed")
+	core.AssertNoError(t, err, "set_defaults")
 
 	// Verify all required fields are set
-	core.AssertNotNil(t, tc.config.Context, "Context should not be nil after SetDefaults")
-	core.AssertNotNil(t, tc.config.Logger, "Logger should not be nil after SetDefaults")
-	core.AssertNotNil(t, tc.config.HashCache, "nanorpc.HashCache should not be nil after SetDefaults")
-	core.AssertNotNil(t, tc.config.WaitReconnect, "WaitReconnect should not be nil after SetDefaults")
+	core.AssertNotNil(t, tc.config.Context, "context")
+	core.AssertNotNil(t, tc.config.Logger, "logger")
+	core.AssertNotNil(t, tc.config.HashCache, "hash_cache")
+	core.AssertNotNil(t, tc.config.WaitReconnect, "wait_reconnect")
 }
 
 func newClientConfigTestCase(name string, config *Config) ClientConfigTestCase {
@@ -64,16 +64,16 @@ func TestClientConfig_SetDefaults(t *testing.T) {
 func TestClientConfig_DefaultValues(t *testing.T) {
 	cfg := &Config{}
 	err := cfg.SetDefaults()
-	core.AssertNoError(t, err, "SetDefaults failed")
+	core.AssertNoError(t, err, "set_defaults")
 
 	// Check specific default values
-	core.AssertEqual(t, 2*time.Second, cfg.DialTimeout, "DialTimeout default mismatch")
-	core.AssertEqual(t, 2*time.Second, cfg.ReadTimeout, "ReadTimeout default mismatch")
-	core.AssertEqual(t, 2*time.Second, cfg.WriteTimeout, "WriteTimeout default mismatch")
-	core.AssertEqual(t, 10*time.Second, cfg.IdleTimeout, "IdleTimeout default mismatch")
-	core.AssertEqual(t, 5*time.Second, cfg.ReconnectDelay, "ReconnectDelay default mismatch")
-	core.AssertEqual(t, 5*time.Second, cfg.KeepAlive, "KeepAlive default mismatch")
-	core.AssertEqual(t, hashCache, cfg.HashCache, "nanorpc.HashCache should be global instance")
+	core.AssertEqual(t, 2*time.Second, cfg.DialTimeout, "dial_timeout")
+	core.AssertEqual(t, 2*time.Second, cfg.ReadTimeout, "read_timeout")
+	core.AssertEqual(t, 2*time.Second, cfg.WriteTimeout, "write_timeout")
+	core.AssertEqual(t, 10*time.Second, cfg.IdleTimeout, "idle_timeout")
+	core.AssertEqual(t, 5*time.Second, cfg.ReconnectDelay, "reconnect_delay")
+	core.AssertEqual(t, 5*time.Second, cfg.KeepAlive, "keep_alive")
+	core.AssertEqual(t, hashCache, cfg.HashCache, "hash_cache")
 }
 
 // TestClientConfig_PreserveExisting tests that existing values are preserved
@@ -100,21 +100,21 @@ func TestClientConfig_PreserveExisting(t *testing.T) {
 	}
 
 	err := cfg.SetDefaults()
-	core.AssertNoError(t, err, "SetDefaults failed")
+	core.AssertNoError(t, err, "set_defaults")
 
 	// Check that custom values are preserved
-	core.AssertEqual(t, customCtx, cfg.Context, "Context was not preserved")
-	core.AssertEqual(t, customLogger, cfg.Logger, "Logger was not preserved")
-	core.AssertEqual(t, customHashCache, cfg.HashCache, "nanorpc.HashCache was not preserved")
-	core.AssertNotNil(t, cfg.WaitReconnect, "WaitReconnect should not be nil")
-	core.AssertEqual(t, 3*time.Second, cfg.DialTimeout, "DialTimeout was not preserved")
-	core.AssertEqual(t, 4*time.Second, cfg.ReadTimeout, "ReadTimeout was not preserved")
-	core.AssertEqual(t, 5*time.Second, cfg.WriteTimeout, "WriteTimeout was not preserved")
-	core.AssertEqual(t, 15*time.Second, cfg.IdleTimeout, "IdleTimeout was not preserved")
-	core.AssertEqual(t, 2*time.Second, cfg.ReconnectDelay, "ReconnectDelay was not preserved")
-	core.AssertEqual(t, 8*time.Second, cfg.KeepAlive, "KeepAlive was not preserved")
-	core.AssertEqual(t, 100, cfg.QueueSize, "QueueSize was not preserved")
-	core.AssertTrue(t, cfg.AlwaysHashPaths, "AlwaysHashPaths was not preserved")
+	core.AssertEqual(t, customCtx, cfg.Context, "context")
+	core.AssertEqual(t, customLogger, cfg.Logger, "logger")
+	core.AssertEqual(t, customHashCache, cfg.HashCache, "hash_cache")
+	core.AssertNotNil(t, cfg.WaitReconnect, "wait_reconnect")
+	core.AssertEqual(t, 3*time.Second, cfg.DialTimeout, "dial_timeout")
+	core.AssertEqual(t, 4*time.Second, cfg.ReadTimeout, "read_timeout")
+	core.AssertEqual(t, 5*time.Second, cfg.WriteTimeout, "write_timeout")
+	core.AssertEqual(t, 15*time.Second, cfg.IdleTimeout, "idle_timeout")
+	core.AssertEqual(t, 2*time.Second, cfg.ReconnectDelay, "reconnect_delay")
+	core.AssertEqual(t, 8*time.Second, cfg.KeepAlive, "keep_alive")
+	core.AssertEqual(t, 100, cfg.QueueSize, "queue_size")
+	core.AssertTrue(t, cfg.AlwaysHashPaths, "always_hash_paths")
 }
 
 // ExportTestCase represents a test case for Export method
@@ -133,17 +133,17 @@ func (tc ExportTestCase) Test(t *testing.T) {
 	result, err := tc.config.Export()
 
 	if tc.expectError {
-		core.AssertError(t, err, "Expected error")
-		core.AssertNil(t, result, "Expected nil result on error")
+		core.AssertError(t, err, "error")
+		core.AssertNil(t, result, "result")
 	} else {
-		core.AssertNoError(t, err, "Expected no error")
-		core.AssertNotNil(t, result, "Expected result")
+		core.AssertNoError(t, err, "error")
+		core.AssertNotNil(t, result, "result")
 
 		// Verify result fields
-		core.AssertEqual(t, tc.config.Remote, result.Remote, "Remote mismatch")
-		core.AssertNotNil(t, result.Context, "Context should not be nil in result")
-		core.AssertNotNil(t, result.Logger, "Logger should not be nil in result")
-		core.AssertNotNil(t, result.WaitReconnect, "WaitReconnect should not be nil in result")
+		core.AssertEqual(t, tc.config.Remote, result.Remote, "remote")
+		core.AssertNotNil(t, result.Context, "context")
+		core.AssertNotNil(t, result.Logger, "logger")
+		core.AssertNotNil(t, result.WaitReconnect, "wait_reconnect")
 	}
 }
 
@@ -174,14 +174,14 @@ func TestClientConfig_getHashCache(t *testing.T) {
 	// Test with nil HashCache
 	cfg := &Config{}
 	hc := cfg.getHashCache()
-	core.AssertNotNil(t, hc, "getHashCache should not return nil")
-	core.AssertEqual(t, hashCache, hc, "Expected global hashCache")
+	core.AssertNotNil(t, hc, "hash_cache")
+	core.AssertEqual(t, hashCache, hc, "hash_cache")
 
 	// Test with custom HashCache
 	customHC := &nanorpc.HashCache{}
 	cfg.HashCache = customHC
 	hc = cfg.getHashCache()
-	core.AssertEqual(t, customHC, hc, "Expected custom nanorpc.HashCache")
+	core.AssertEqual(t, customHC, hc, "hash_cache")
 }
 
 // GetPathOneOfTestCase represents a test case for newGetPathOneOf
@@ -223,9 +223,9 @@ func testAlwaysHashPathsFalse(t *testing.T, hc *nanorpc.HashCache) {
 	result := getPathOneOf("/test/path")
 
 	pathOneof, ok := core.AssertTypeIs[*nanorpc.NanoRPCRequest_Path](
-		t, result, "Expected *nanorpc.NanoRPCRequest_Path")
+		t, result, "path_oneof")
 	if ok {
-		core.AssertEqual(t, "/test/path", pathOneof.Path, "Path mismatch")
+		core.AssertEqual(t, "/test/path", pathOneof.Path, "path")
 	}
 }
 
@@ -239,17 +239,17 @@ func testAlwaysHashPathsTrue(t *testing.T, hc *nanorpc.HashCache) {
 	result := getPathOneOf("/test/path")
 
 	pathHashOneof, ok := core.AssertTypeIs[*nanorpc.NanoRPCRequest_PathHash](t, result,
-		"Expected *nanorpc.NanoRPCRequest_PathHash")
+		"path_hash_oneof")
 	if ok {
-		core.AssertNotEqual(t, uint32(0), pathHashOneof.PathHash, "Expected non-zero hash")
+		core.AssertNotEqual(t, uint32(0), pathHashOneof.PathHash, "path_hash")
 	}
 
 	// Test consistency
 	result2 := getPathOneOf("/test/path")
 	pathHashOneof2, ok := core.AssertTypeIs[*nanorpc.NanoRPCRequest_PathHash](t, result2,
-		"Expected *nanorpc.NanoRPCRequest_PathHash")
+		"path_hash_oneof")
 	if ok {
-		core.AssertEqual(t, pathHashOneof.PathHash, pathHashOneof2.PathHash, "Hash should be consistent")
+		core.AssertEqual(t, pathHashOneof.PathHash, pathHashOneof2.PathHash, "path_hash")
 	}
 }
 
@@ -264,9 +264,9 @@ func testAlwaysHashPathsTrueNilCache(t *testing.T, _ *nanorpc.HashCache) {
 	result := getPathOneOf("/test/path")
 
 	pathHashOneof, ok := core.AssertTypeIs[*nanorpc.NanoRPCRequest_PathHash](t, result,
-		"Expected *nanorpc.NanoRPCRequest_PathHash")
+		"path_hash_oneof")
 	if ok {
-		core.AssertNotEqual(t, uint32(0), pathHashOneof.PathHash, "Expected non-zero hash")
+		core.AssertNotEqual(t, uint32(0), pathHashOneof.PathHash, "path_hash")
 	}
 }
 
@@ -312,19 +312,19 @@ func TestClientConfig_CallbacksPreserved(t *testing.T) {
 	cfg, onDisconnectCalled, onErrorCalled := createConfigWithCallbacks()
 
 	err := cfg.SetDefaults()
-	core.AssertNoError(t, err, "SetDefaults failed")
+	core.AssertNoError(t, err, "set_defaults")
 
 	// Test that callbacks are preserved
-	core.AssertNotNil(t, cfg.OnConnect, "OnConnect callback should not be nil")
-	core.AssertNotNil(t, cfg.OnDisconnect, "OnDisconnect callback should not be nil")
-	core.AssertNotNil(t, cfg.OnError, "OnError callback should not be nil")
+	core.AssertNotNil(t, cfg.OnConnect, "on_connect")
+	core.AssertNotNil(t, cfg.OnDisconnect, "on_disconnect")
+	core.AssertNotNil(t, cfg.OnError, "on_error")
 
 	// Test that they work (skip OnConnect as it needs WorkGroup interface)
 	err = cfg.OnDisconnect(context.Background())
-	core.AssertNoError(t, err, "OnDisconnect failed")
-	core.AssertTrue(t, *onDisconnectCalled, "OnDisconnect callback was not called")
+	core.AssertNoError(t, err, "on_disconnect")
+	core.AssertTrue(t, *onDisconnectCalled, "on_disconnect_called")
 
 	err = cfg.OnError(context.Background(), context.Canceled)
-	core.AssertNoError(t, err, "OnError failed")
-	core.AssertTrue(t, *onErrorCalled, "OnError callback was not called")
+	core.AssertNoError(t, err, "on_error")
+	core.AssertTrue(t, *onErrorCalled, "on_error_called")
 }

--- a/pkg/nanorpc/client/logger_test.go
+++ b/pkg/nanorpc/client/logger_test.go
@@ -31,7 +31,7 @@ func newTestAddr(addr string) mockAddr {
 func TestClientDefaultLogger(t *testing.T) {
 	c := &Client{}
 	logger := c.getLogger()
-	core.AssertNotNil(t, logger, "default logger should not be nil")
+	core.AssertNotNil(t, logger, "logger")
 
 	// Verify it doesn't panic
 	logger.Info().Print("test message")
@@ -42,7 +42,7 @@ func TestClientCustomLogger(t *testing.T) {
 	c := newTestClient(customLogger)
 	logger := c.getLogger()
 
-	core.AssertEqual[slog.Logger](t, customLogger, logger, "should return custom logger")
+	core.AssertEqual[slog.Logger](t, customLogger, logger, "logger")
 }
 
 type clientWithMethodTestCase struct {
@@ -59,17 +59,17 @@ func (tc *clientWithMethodTestCase) test(t *testing.T) {
 	addr := newTestAddr(tc.address)
 
 	logger, ok := tc.method(c, addr)
-	core.AssertTrue(t, ok, tc.name+" should return true")
-	core.AssertNotNil(t, logger, tc.name+" should return a logger")
+	core.AssertTrue(t, ok, tc.name+" ok")
+	core.AssertNotNil(t, logger, tc.name+" logger")
 
 	// Check expected field
-	ml, ok := core.AssertTypeIs[*testutils.MockFieldLogger](t, logger, "expected MockFieldLogger")
+	ml, ok := core.AssertTypeIs[*testutils.MockFieldLogger](t, logger, "MockFieldLogger")
 	if !ok {
 		return
 	}
 	val, ok := testutils.GetField[string, any](ml.Fields, tc.expectField)
-	core.AssertTrue(t, ok, "logger should have %s field", tc.expectField)
-	core.AssertEqual(t, tc.expectValue, val, "should have "+tc.expectField+" field")
+	core.AssertTrue(t, ok, "field %s", tc.expectField)
+	core.AssertEqual(t, tc.expectValue, val, tc.expectField)
 }
 
 func TestClientWithMethods(t *testing.T) {
@@ -102,19 +102,19 @@ func TestClientWithError(t *testing.T) {
 	testErr := core.ErrInvalid
 
 	logger, ok := c.WithError(addr, testErr)
-	core.AssertTrue(t, ok, "WithError should return true")
-	core.AssertNotNil(t, logger, "error logger should not be nil")
+	core.AssertTrue(t, ok, "WithError ok")
+	core.AssertNotNil(t, logger, "logger")
 
 	// Check fields
-	ml, ok := core.AssertTypeIs[*testutils.MockFieldLogger](t, logger, "expected MockFieldLogger")
+	ml, ok := core.AssertTypeIs[*testutils.MockFieldLogger](t, logger, "MockFieldLogger")
 	if !ok {
 		return
 	}
 	if addr, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields, "remote_addr", "remote_addr"); ok {
-		core.AssertEqual(t, "10.0.0.1:443", addr, "should have remote address")
+		core.AssertEqual(t, "10.0.0.1:443", addr, "remote_addr")
 	}
 	if err, ok := testutils.AssertFieldTypeIs[error](t, ml.Fields, "error", "error"); ok {
-		core.AssertEqual(t, testErr, err, "should have error field")
+		core.AssertEqual(t, testErr, err, "error")
 	}
 }
 
@@ -124,16 +124,16 @@ func TestClientGetErrorLogger(t *testing.T) {
 	testErr := core.ErrNilReceiver
 
 	logger, ok := c.getErrorLogger(testErr)
-	core.AssertTrue(t, ok, "getErrorLogger should return true")
-	core.AssertNotNil(t, logger, "error logger should not be nil")
+	core.AssertTrue(t, ok, "getErrorLogger ok")
+	core.AssertNotNil(t, logger, "logger")
 
 	// Check error field
-	ml, ok := core.AssertTypeIs[*testutils.MockFieldLogger](t, logger, "expected MockFieldLogger")
+	ml, ok := core.AssertTypeIs[*testutils.MockFieldLogger](t, logger, "MockFieldLogger")
 	if !ok {
 		return
 	}
 	if err, ok := testutils.AssertFieldTypeIs[error](t, ml.Fields, "error", "error"); ok {
-		core.AssertEqual(t, testErr, err, "should have error field")
+		core.AssertEqual(t, testErr, err, "error")
 	}
 }
 
@@ -152,9 +152,9 @@ func (tc *thresholdTestCase) test(t *testing.T) {
 
 	_, ok := tc.method(c, addr)
 	if tc.expected {
-		core.AssertTrue(t, ok, tc.name+" should be enabled")
+		core.AssertTrue(t, ok, tc.name+" enabled")
 	} else {
-		core.AssertFalse(t, ok, tc.name+" should be disabled")
+		core.AssertFalse(t, ok, tc.name+" disabled")
 	}
 }
 
@@ -201,19 +201,19 @@ func TestSessionGetLogger(t *testing.T) {
 	cs := newTestSession(c, "10.0.0.1:8080")
 
 	logger := cs.getLogger()
-	core.AssertNotNil(t, logger, "session logger should not be nil")
+	core.AssertNotNil(t, logger, "logger")
 
 	// Check fields
-	ml, ok := core.AssertTypeIs[*testutils.MockFieldLogger](t, logger, "expected MockFieldLogger")
+	ml, ok := core.AssertTypeIs[*testutils.MockFieldLogger](t, logger, "MockFieldLogger")
 	if !ok {
 		return
 	}
 	component, ok := testutils.GetField[string, string](ml.Fields, "component")
-	core.AssertTrue(t, ok, "logger should have component field")
-	core.AssertEqual(t, "session", component, "should have session component")
+	core.AssertTrue(t, ok, "component field")
+	core.AssertEqual(t, "session", component, "component")
 	addr, ok := testutils.GetField[string, string](ml.Fields, "remote_addr")
-	core.AssertTrue(t, ok, "logger should have remote_addr field")
-	core.AssertEqual(t, "10.0.0.1:8080", addr, "should have remote address field")
+	core.AssertTrue(t, ok, "remote_addr field")
+	core.AssertEqual(t, "10.0.0.1:8080", addr, "remote_addr")
 }
 
 func TestSessionWithDebug(t *testing.T) {
@@ -222,8 +222,8 @@ func TestSessionWithDebug(t *testing.T) {
 	cs := newTestSession(c, "192.168.1.100:9000")
 
 	logger, ok := cs.WithDebug()
-	core.AssertTrue(t, ok, "WithDebug should return true for debug level")
-	core.AssertNotNil(t, logger, "debug logger should not be nil")
+	core.AssertTrue(t, ok, "WithDebug ok")
+	core.AssertNotNil(t, logger, "logger")
 }
 
 func TestSessionLogMethods(t *testing.T) {
@@ -242,7 +242,7 @@ func TestSessionLogMethods(t *testing.T) {
 	cs.LogError(testErr, nil, "error message")
 
 	// Verify no panic
-	core.AssertNotNil(t, cs, "session should not be nil")
+	core.AssertNotNil(t, cs, "session")
 }
 
 // Test missing Client logging methods
@@ -285,19 +285,19 @@ func TestClientWithWarn(t *testing.T) {
 	testErr := core.ErrInvalid
 
 	logger, ok := c.WithWarn(addr, testErr)
-	core.AssertTrue(t, ok, "WithWarn should return true when warn enabled")
-	core.AssertNotNil(t, logger, "WithWarn should return a logger")
+	core.AssertTrue(t, ok, "WithWarn ok")
+	core.AssertNotNil(t, logger, "logger")
 
 	// Check fields are added
-	ml, ok := core.AssertTypeIs[*testutils.MockFieldLogger](t, logger, "expected MockFieldLogger")
+	ml, ok := core.AssertTypeIs[*testutils.MockFieldLogger](t, logger, "MockFieldLogger")
 	if !ok {
 		return
 	}
 	if err, ok := testutils.AssertFieldTypeIs[error](t, ml.Fields, "error", "error"); ok {
-		core.AssertEqual(t, testErr, err, "should have error field")
+		core.AssertEqual(t, testErr, err, "error")
 	}
 	if addrVal, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields, "remote_addr", "remote_addr"); ok {
-		core.AssertEqual(t, "127.0.0.1:8080", addrVal, "should have remote address field")
+		core.AssertEqual(t, "127.0.0.1:8080", addrVal, "remote_addr")
 	}
 }
 
@@ -327,16 +327,16 @@ func TestSessionWithWarn(t *testing.T) {
 	testErr := core.ErrInvalid
 
 	logger, ok := cs.WithWarn(testErr)
-	core.AssertTrue(t, ok, "WithWarn should return true when warn enabled")
-	core.AssertNotNil(t, logger, "WithWarn should return a logger")
+	core.AssertTrue(t, ok, "WithWarn ok")
+	core.AssertNotNil(t, logger, "logger")
 
 	// Check error field is added
-	ml, ok := core.AssertTypeIs[*testutils.MockFieldLogger](t, logger, "expected MockFieldLogger")
+	ml, ok := core.AssertTypeIs[*testutils.MockFieldLogger](t, logger, "MockFieldLogger")
 	if !ok {
 		return
 	}
 	if err, ok := testutils.AssertFieldTypeIs[error](t, ml.Fields, "error", "error"); ok {
-		core.AssertEqual(t, testErr, err, "should have error field")
+		core.AssertEqual(t, testErr, err, "error")
 	}
 }
 
@@ -364,8 +364,8 @@ func TestSessionWithInfo(t *testing.T) {
 	cs := newTestSession(c, "127.0.0.1:8080")
 
 	logger, ok := cs.WithInfo()
-	core.AssertTrue(t, ok, "WithInfo should return true when info enabled")
-	core.AssertNotNil(t, logger, "WithInfo should return a logger")
+	core.AssertTrue(t, ok, "WithInfo ok")
+	core.AssertNotNil(t, logger, "logger")
 }
 
 // Test Session WithError method which was missing
@@ -377,15 +377,15 @@ func TestSessionWithError(t *testing.T) {
 	testErr := core.ErrInvalid
 
 	logger, ok := cs.WithError(testErr)
-	core.AssertTrue(t, ok, "WithError should return true when error enabled")
-	core.AssertNotNil(t, logger, "WithError should return a logger")
+	core.AssertTrue(t, ok, "WithError ok")
+	core.AssertNotNil(t, logger, "logger")
 
 	// Check error field is added
-	ml, ok := core.AssertTypeIs[*testutils.MockFieldLogger](t, logger, "expected MockFieldLogger")
+	ml, ok := core.AssertTypeIs[*testutils.MockFieldLogger](t, logger, "MockFieldLogger")
 	if !ok {
 		return
 	}
 	if err, ok := testutils.AssertFieldTypeIs[error](t, ml.Fields, "error", "error"); ok {
-		core.AssertEqual(t, testErr, err, "should have error field")
+		core.AssertEqual(t, testErr, err, "error")
 	}
 }

--- a/pkg/nanorpc/client/logger_test.go
+++ b/pkg/nanorpc/client/logger_test.go
@@ -110,15 +110,11 @@ func TestClientWithError(t *testing.T) {
 	if !ok {
 		return
 	}
-	if addr, ok := testutils.GetField[string, string](ml.Fields, "remote_addr"); ok {
+	if addr, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields, "remote_addr", "remote_addr"); ok {
 		core.AssertEqual(t, "10.0.0.1:443", addr, "should have remote address")
-	} else {
-		t.Error("logger should have remote_addr field")
 	}
-	if err, ok := testutils.GetField[string, error](ml.Fields, "error"); ok {
+	if err, ok := testutils.AssertFieldTypeIs[error](t, ml.Fields, "error", "error"); ok {
 		core.AssertEqual(t, testErr, err, "should have error field")
-	} else {
-		t.Error("logger should have error field")
 	}
 }
 
@@ -136,10 +132,8 @@ func TestClientGetErrorLogger(t *testing.T) {
 	if !ok {
 		return
 	}
-	if err, ok := testutils.GetField[string, error](ml.Fields, "error"); ok {
+	if err, ok := testutils.AssertFieldTypeIs[error](t, ml.Fields, "error", "error"); ok {
 		core.AssertEqual(t, testErr, err, "should have error field")
-	} else {
-		t.Error("logger should have error field")
 	}
 }
 
@@ -299,15 +293,11 @@ func TestClientWithWarn(t *testing.T) {
 	if !ok {
 		return
 	}
-	if err, ok := testutils.GetField[string, error](ml.Fields, "error"); ok {
+	if err, ok := testutils.AssertFieldTypeIs[error](t, ml.Fields, "error", "error"); ok {
 		core.AssertEqual(t, testErr, err, "should have error field")
-	} else {
-		t.Error("logger should have error field")
 	}
-	if addrVal, ok := testutils.GetField[string, string](ml.Fields, "remote_addr"); ok {
+	if addrVal, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields, "remote_addr", "remote_addr"); ok {
 		core.AssertEqual(t, "127.0.0.1:8080", addrVal, "should have remote address field")
-	} else {
-		t.Error("logger should have remote_addr field")
 	}
 }
 
@@ -345,10 +335,8 @@ func TestSessionWithWarn(t *testing.T) {
 	if !ok {
 		return
 	}
-	if err, ok := testutils.GetField[string, error](ml.Fields, "error"); ok {
+	if err, ok := testutils.AssertFieldTypeIs[error](t, ml.Fields, "error", "error"); ok {
 		core.AssertEqual(t, testErr, err, "should have error field")
-	} else {
-		t.Error("logger should have error field")
 	}
 }
 
@@ -397,9 +385,7 @@ func TestSessionWithError(t *testing.T) {
 	if !ok {
 		return
 	}
-	if err, ok := testutils.GetField[string, error](ml.Fields, "error"); ok {
+	if err, ok := testutils.AssertFieldTypeIs[error](t, ml.Fields, "error", "error"); ok {
 		core.AssertEqual(t, testErr, err, "should have error field")
-	} else {
-		t.Error("logger should have error field")
 	}
 }

--- a/pkg/nanorpc/client/request_counter_test.go
+++ b/pkg/nanorpc/client/request_counter_test.go
@@ -10,7 +10,7 @@ import (
 func testBasicCounter(t *testing.T) {
 	t.Helper()
 	counter, err := NewRequestCounter()
-	core.AssertNoError(t, err, "NewRequestCounter failed")
+	core.AssertNoError(t, err, "counter")
 
 	// Test first ID
 	id1 := counter.Next()
@@ -46,7 +46,7 @@ func TestRequestCounter_NilReceiver(t *testing.T) {
 func testSkipZero(t *testing.T) {
 	t.Helper()
 	counter, err := NewRequestCounter()
-	core.AssertNoError(t, err, "NewRequestCounter failed")
+	core.AssertNoError(t, err, "counter")
 
 	// Generate many IDs to test that zero is never returned
 	for i := range 1000 {
@@ -64,7 +64,7 @@ func TestRequestCounter_SkipZero(t *testing.T) {
 func testConcurrency(t *testing.T) {
 	t.Helper()
 	counter, err := NewRequestCounter()
-	core.AssertNoError(t, err, "NewRequestCounter failed")
+	core.AssertNoError(t, err, "counter")
 
 	numGoroutines := 100
 	numIDsPerGoroutine := 10
@@ -101,7 +101,7 @@ func TestRequestCounter_Concurrency(t *testing.T) {
 func testWraparound(t *testing.T) {
 	t.Helper()
 	counter, err := NewRequestCounter()
-	core.AssertNoError(t, err, "NewRequestCounter failed")
+	core.AssertNoError(t, err, "counter")
 
 	// Simulate wraparound by setting counter to near max
 	counter.counter.Store(2147483646) // Just below MaxInt32
@@ -126,7 +126,7 @@ func testRandomRequestID(t *testing.T) {
 	// Test that NewRandomRequestID generates valid IDs
 	for range 100 {
 		id, err := NewRandomRequestID()
-		core.AssertNoError(t, err, "NewRandomRequestID failed")
+		core.AssertNoError(t, err, "random_id")
 		core.AssertTrue(t, id > 0, "NewRandomRequestID should return positive ID")
 	}
 }
@@ -144,7 +144,7 @@ func testRandomRequestIDUniqueness(t *testing.T) {
 
 	for range numIDs {
 		id, err := NewRandomRequestID()
-		core.AssertNoError(t, err, "NewRandomRequestID failed")
+		core.AssertNoError(t, err, "random_id")
 		seen[id] = true
 	}
 
@@ -163,10 +163,10 @@ func testStartingPoint(t *testing.T) {
 	t.Helper()
 	// Test that different counters start at different points
 	counter1, err := NewRequestCounter()
-	core.AssertNoError(t, err, "NewRequestCounter failed")
+	core.AssertNoError(t, err, "counter")
 
 	counter2, err := NewRequestCounter()
-	core.AssertNoError(t, err, "NewRequestCounter failed")
+	core.AssertNoError(t, err, "counter")
 
 	id1 := counter1.Next()
 	id2 := counter2.Next()

--- a/pkg/nanorpc/client/request_test.go
+++ b/pkg/nanorpc/client/request_test.go
@@ -25,7 +25,7 @@ func (tc requestTypeTestCase) test(t *testing.T) {
 	}
 
 	// Verify the request type matches expectation
-	core.AssertEqual(t, tc.expectedType, req.RequestType, "RequestType mismatch")
+	core.AssertEqual(t, tc.expectedType, req.RequestType, "request_type")
 }
 
 func newRequestTypeTestCase(name string, requestType, expectedType nanorpc.NanoRPCRequest_Type) requestTypeTestCase {
@@ -120,7 +120,7 @@ func TestPathOneofTypes(t *testing.T) {
 	pathOneof, ok := core.AssertTypeIs[*nanorpc.NanoRPCRequest_Path](t, pathReq.PathOneof,
 		"Expected *nanorpc.NanoRPCRequest_Path")
 	if ok {
-		core.AssertEqual(t, "/events", pathOneof.Path, "Path mismatch")
+		core.AssertEqual(t, "/events", pathOneof.Path, "path")
 	}
 
 	// Test hash path
@@ -134,7 +134,7 @@ func TestPathOneofTypes(t *testing.T) {
 	hashOneof, ok := core.AssertTypeIs[*nanorpc.NanoRPCRequest_PathHash](t, hashReq.PathOneof,
 		"Expected *nanorpc.NanoRPCRequest_PathHash")
 	if ok {
-		core.AssertEqual(t, uint32(0x12345678), hashOneof.PathHash, "Hash mismatch")
+		core.AssertEqual(t, uint32(0x12345678), hashOneof.PathHash, "path_hash")
 	}
 }
 

--- a/pkg/nanorpc/nanorpc_protocol_test.go
+++ b/pkg/nanorpc/nanorpc_protocol_test.go
@@ -82,11 +82,9 @@ func (tc statusCodeTestCase) test(t *testing.T) {
 
 	err := ResponseAsError(res)
 	if tc.isError {
-		if err == nil {
-			t.Errorf("Expected error for status %v", tc.value)
-		}
-	} else if err != nil {
-		t.Errorf("Expected no error for status %v, got: %v", tc.value, err)
+		core.AssertError(t, err, "error")
+	} else {
+		core.AssertNoError(t, err, "no error")
 	}
 }
 

--- a/pkg/nanorpc/nanorpc_test.go
+++ b/pkg/nanorpc/nanorpc_test.go
@@ -105,7 +105,7 @@ func (tc decodeResponseDataTestCase) Test(t *testing.T) {
 	result, hasData, err := DecodeResponseData(tc.response, out)
 
 	if tc.wantErr {
-		core.AssertError(t, err, "expected error")
+		core.AssertError(t, err, "error")
 		return
 	}
 

--- a/pkg/nanorpc/server/logger_test.go
+++ b/pkg/nanorpc/server/logger_test.go
@@ -15,7 +15,7 @@ import (
 func TestServerDefaultLogger(t *testing.T) {
 	s := &Server{}
 	logger := s.getLogger()
-	core.AssertNotNil(t, logger, "default logger should not be nil")
+	core.AssertNotNil(t, logger, "logger")
 
 	// Verify it doesn't panic
 	logger.Info().Print("test message")
@@ -27,7 +27,7 @@ func TestServerCustomLogger(t *testing.T) {
 	s := &Server{logger: customLogger}
 	logger := s.getLogger()
 
-	core.AssertEqual[slog.Logger](t, customLogger, logger, "should return custom logger")
+	core.AssertEqual[slog.Logger](t, customLogger, logger, "logger")
 }
 
 // Test Server.WithDebug
@@ -42,7 +42,7 @@ func TestServerWithDebug(t *testing.T) {
 
 	// Verify the logger has the correct level
 	if ml, ok := logger.(*testutils.MockFieldLogger); ok {
-		core.AssertEqual(t, slog.Debug, ml.CurrentLevel, "should have Debug level")
+		core.AssertEqual(t, slog.Debug, ml.CurrentLevel, "level")
 	}
 }
 
@@ -61,7 +61,7 @@ func TestServerLogInfo(t *testing.T) {
 	s.LogInfo(nil, "this should not log")
 
 	// No panic means test passed
-	core.AssertTrue(t, true, "LogInfo executed without panic")
+	core.AssertTrue(t, true, "LogInfo no panic")
 }
 
 // Test Server.WithError
@@ -72,13 +72,13 @@ func TestServerWithError(t *testing.T) {
 	testErr := errors.New("test error")
 
 	logger, ok := s.WithError(testErr)
-	core.AssertTrue(t, ok, "WithError should return true when error enabled")
-	core.AssertNotNil(t, logger, "WithError should return a logger")
+	core.AssertTrue(t, ok, "WithError ok")
+	core.AssertNotNil(t, logger, "WithError logger")
 
 	// Check error field was added
 	if ml, ok := logger.(*testutils.MockFieldLogger); ok {
 		if err, ok := testutils.AssertFieldTypeIs[error](t, ml.Fields, utils.FieldError, "error field"); ok {
-			core.AssertEqual(t, testErr, err, "should have error field")
+			core.AssertEqual(t, testErr, err, "error field")
 		}
 	}
 }
@@ -90,8 +90,8 @@ func TestSessionManagerWithInfo(t *testing.T) {
 	sm := &DefaultSessionManager{logger: mockLog}
 
 	logger, ok := sm.WithInfo()
-	core.AssertTrue(t, ok, "WithInfo should return true when info enabled")
-	core.AssertNotNil(t, logger, "WithInfo should return a logger")
+	core.AssertTrue(t, ok, "WithInfo ok")
+	core.AssertNotNil(t, logger, "WithInfo logger")
 }
 
 // Test Session logging with fields
@@ -108,26 +108,26 @@ func TestSessionWithDebug(t *testing.T) {
 	s := NewDefaultSession(mockConn, nil, mockLog)
 
 	logger, ok := s.WithDebug()
-	core.AssertTrue(t, ok, "WithDebug should return true when debug enabled")
-	core.AssertNotNil(t, logger, "WithDebug should return a logger")
+	core.AssertTrue(t, ok, "WithDebug ok")
+	core.AssertNotNil(t, logger, "WithDebug logger")
 
 	// Check session fields are added
 	if ml, ok := logger.(*testutils.MockFieldLogger); ok {
 		// Check component field
 		if component, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields,
 			utils.FieldComponent, "component field"); ok {
-			core.AssertEqual(t, utils.ComponentSession, component, "should have session component")
+			core.AssertEqual(t, utils.ComponentSession, component, "component")
 		}
 
 		// Check session ID field
 		if sid, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields, utils.FieldSessionID, "session_id field"); ok {
-			core.AssertEqual(t, s.ID(), sid, "should have session ID")
+			core.AssertEqual(t, s.ID(), sid, "session_id")
 		}
 
 		// Check remote address field
 		if addr, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields,
 			utils.FieldRemoteAddr, "remote_addr field"); ok {
-			core.AssertEqual(t, "127.0.0.1:12345", addr, "should have remote address")
+			core.AssertEqual(t, "127.0.0.1:12345", addr, "remote_addr")
 		}
 	}
 }
@@ -152,8 +152,8 @@ func TestServerLogAccept(t *testing.T) {
 	s.logAccept(conn)
 
 	// Verify the method handles the connection properly
-	core.AssertEqual(t, "127.0.0.1:8080", conn.LocalAddr().String(), "local address should match")
-	core.AssertEqual(t, "192.168.1.1:12345", conn.RemoteAddr().String(), "remote address should match")
+	core.AssertEqual(t, "127.0.0.1:8080", conn.LocalAddr().String(), "local addr")
+	core.AssertEqual(t, "192.168.1.1:12345", conn.RemoteAddr().String(), "remote addr")
 }
 
 // Test additional Server logging methods
@@ -178,8 +178,8 @@ func TestServerWithWarn(t *testing.T) {
 	testErr := errors.New("test warning")
 
 	logger, ok := s.WithWarn(testErr)
-	core.AssertTrue(t, ok, "WithWarn should return true when warn enabled")
-	core.AssertNotNil(t, logger, "WithWarn should return a logger")
+	core.AssertTrue(t, ok, "WithWarn ok")
+	core.AssertNotNil(t, logger, "WithWarn logger")
 }
 
 func TestServerLogWarn(_ *testing.T) {
@@ -213,8 +213,8 @@ func TestSessionManagerWithDebug(t *testing.T) {
 	sm := &DefaultSessionManager{logger: mockLog}
 
 	logger, ok := sm.WithDebug()
-	core.AssertTrue(t, ok, "WithDebug should return true when debug enabled")
-	core.AssertNotNil(t, logger, "WithDebug should return a logger")
+	core.AssertTrue(t, ok, "WithDebug ok")
+	core.AssertNotNil(t, logger, "WithDebug logger")
 }
 
 func TestSessionManagerLogDebug(_ *testing.T) {
@@ -237,8 +237,8 @@ func TestSessionManagerWithWarn(t *testing.T) {
 	testErr := errors.New("test warning")
 
 	logger, ok := sm.WithWarn(testErr)
-	core.AssertTrue(t, ok, "WithWarn should return true when warn enabled")
-	core.AssertNotNil(t, logger, "WithWarn should return a logger")
+	core.AssertTrue(t, ok, "WithWarn ok")
+	core.AssertNotNil(t, logger, "WithWarn logger")
 }
 
 func TestSessionManagerLogWarn(_ *testing.T) {
@@ -262,8 +262,8 @@ func TestSessionManagerWithError(t *testing.T) {
 	testErr := errors.New("test error")
 
 	logger, ok := sm.WithError(testErr)
-	core.AssertTrue(t, ok, "WithError should return true when error enabled")
-	core.AssertNotNil(t, logger, "WithError should return a logger")
+	core.AssertTrue(t, ok, "WithError ok")
+	core.AssertNotNil(t, logger, "WithError logger")
 }
 
 func TestSessionManagerLogError(_ *testing.T) {
@@ -284,8 +284,8 @@ func TestSessionWithInfo(t *testing.T) {
 	s := NewDefaultSession(mockConn, nil, mockLog)
 
 	logger, ok := s.WithInfo()
-	core.AssertTrue(t, ok, "WithInfo should return true when info enabled")
-	core.AssertNotNil(t, logger, "WithInfo should return a logger")
+	core.AssertTrue(t, ok, "WithInfo ok")
+	core.AssertNotNil(t, logger, "WithInfo logger")
 }
 
 func TestSessionLogDebug(_ *testing.T) {
@@ -324,8 +324,8 @@ func TestSessionWithWarn(t *testing.T) {
 	testErr := errors.New("test warning")
 
 	logger, ok := s.WithWarn(testErr)
-	core.AssertTrue(t, ok, "WithWarn should return true when warn enabled")
-	core.AssertNotNil(t, logger, "WithWarn should return a logger")
+	core.AssertTrue(t, ok, "WithWarn ok")
+	core.AssertNotNil(t, logger, "WithWarn logger")
 }
 
 func TestSessionLogWarn(_ *testing.T) {
@@ -351,8 +351,8 @@ func TestSessionWithError(t *testing.T) {
 	testErr := errors.New("test error")
 
 	logger, ok := s.WithError(testErr)
-	core.AssertTrue(t, ok, "WithError should return true when error enabled")
-	core.AssertNotNil(t, logger, "WithError should return a logger")
+	core.AssertTrue(t, ok, "WithError ok")
+	core.AssertNotNil(t, logger, "WithError logger")
 }
 
 func TestSessionLogError(_ *testing.T) {

--- a/pkg/nanorpc/server/logger_test.go
+++ b/pkg/nanorpc/server/logger_test.go
@@ -77,10 +77,8 @@ func TestServerWithError(t *testing.T) {
 
 	// Check error field was added
 	if ml, ok := logger.(*testutils.MockFieldLogger); ok {
-		if err, ok := testutils.GetField[string, error](ml.Fields, utils.FieldError); ok {
+		if err, ok := testutils.AssertFieldTypeIs[error](t, ml.Fields, utils.FieldError, "error field"); ok {
 			core.AssertEqual(t, testErr, err, "should have error field")
-		} else {
-			t.Error("logger should have error field")
 		}
 	}
 }
@@ -116,24 +114,20 @@ func TestSessionWithDebug(t *testing.T) {
 	// Check session fields are added
 	if ml, ok := logger.(*testutils.MockFieldLogger); ok {
 		// Check component field
-		if component, ok := testutils.GetField[string, string](ml.Fields, utils.FieldComponent); ok {
+		if component, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields,
+			utils.FieldComponent, "component field"); ok {
 			core.AssertEqual(t, utils.ComponentSession, component, "should have session component")
-		} else {
-			t.Error("logger should have component field")
 		}
 
 		// Check session ID field
-		if sid, ok := testutils.GetField[string, string](ml.Fields, utils.FieldSessionID); ok {
+		if sid, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields, utils.FieldSessionID, "session_id field"); ok {
 			core.AssertEqual(t, s.ID(), sid, "should have session ID")
-		} else {
-			t.Error("logger should have session_id field")
 		}
 
 		// Check remote address field
-		if addr, ok := testutils.GetField[string, string](ml.Fields, utils.FieldRemoteAddr); ok {
+		if addr, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields,
+			utils.FieldRemoteAddr, "remote_addr field"); ok {
 			core.AssertEqual(t, "127.0.0.1:12345", addr, "should have remote address")
-		} else {
-			t.Error("logger should have remote_addr field")
 		}
 	}
 }

--- a/pkg/nanorpc/testutils_test.go
+++ b/pkg/nanorpc/testutils_test.go
@@ -144,7 +144,7 @@ func (h *EncodeDecodeTestHelper) assertPathEqual(expected, actual isNanoRPCReque
 
 func (h *EncodeDecodeTestHelper) assertPathOneofNotNil(expected, actual isNanoRPCRequest_PathOneof) {
 	h.t.Helper()
-	if !core.AssertNotNil(h.t, expected, "expected PathOneof") {
+	if !core.AssertNotNil(h.t, expected, "PathOneof") {
 		h.t.FailNow()
 	}
 	if !core.AssertNotNil(h.t, actual, "actual PathOneof") {

--- a/pkg/nanorpc/utils/fields_test.go
+++ b/pkg/nanorpc/utils/fields_test.go
@@ -25,21 +25,21 @@ func TestWithRemoteAddr(t *testing.T) {
 
 	// Test with valid logger and addr
 	result := WithRemoteAddr(mockLog, addr)
-	core.AssertNotNil(t, result, "should return a logger")
+	core.AssertNotNil(t, result, "logger")
 
 	if ml, ok := result.(*testutils.MockFieldLogger); ok {
 		if remoteAddr, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields, FieldRemoteAddr, "remote_addr"); ok {
-			core.AssertEqual(t, "127.0.0.1:8080", remoteAddr, "should have remote address")
+			core.AssertEqual(t, "127.0.0.1:8080", remoteAddr, "remote_addr")
 		}
 	}
 
 	// Test with nil logger
 	result = WithRemoteAddr(nil, addr)
-	core.AssertNil(t, result, "should return nil for nil logger")
+	core.AssertNil(t, result, "nil logger result")
 
 	// Test with nil addr
 	result = WithRemoteAddr(mockLog, nil)
-	core.AssertEqual[slog.Logger](t, mockLog, result, "should return original logger for nil addr")
+	core.AssertEqual[slog.Logger](t, mockLog, result, "original logger")
 }
 
 func TestWithLocalAddr(t *testing.T) {
@@ -47,11 +47,11 @@ func TestWithLocalAddr(t *testing.T) {
 	addr := mockAddr{network: "tcp", address: "192.168.1.1:9090"}
 
 	result := WithLocalAddr(mockLog, addr)
-	core.AssertNotNil(t, result, "should return a logger")
+	core.AssertNotNil(t, result, "logger")
 
 	if ml, ok := result.(*testutils.MockFieldLogger); ok {
 		if localAddr, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields, FieldLocalAddr, "local_addr"); ok {
-			core.AssertEqual(t, "192.168.1.1:9090", localAddr, "should have local address")
+			core.AssertEqual(t, "192.168.1.1:9090", localAddr, "local_addr")
 		}
 	}
 }
@@ -66,23 +66,23 @@ func TestWithConnAddrs(t *testing.T) {
 	}
 
 	result := WithConnAddrs(mockLog, conn)
-	core.AssertNotNil(t, result, "should return a logger")
+	core.AssertNotNil(t, result, "logger")
 
 	if ml, ok := result.(*testutils.MockFieldLogger); ok {
 		// Check remote address
 		if remoteAddr, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields, FieldRemoteAddr, "remote_addr"); ok {
-			core.AssertEqual(t, "192.168.1.1:9090", remoteAddr, "should have remote address")
+			core.AssertEqual(t, "192.168.1.1:9090", remoteAddr, "remote_addr")
 		}
 
 		// Check local address
 		if localAddr, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields, FieldLocalAddr, "local_addr"); ok {
-			core.AssertEqual(t, "127.0.0.1:8080", localAddr, "should have local address")
+			core.AssertEqual(t, "127.0.0.1:8080", localAddr, "local_addr")
 		}
 	}
 
 	// Test with nil connection
 	result = WithConnAddrs(mockLog, nil)
-	core.AssertEqual[slog.Logger](t, mockLog, result, "should return original logger for nil conn")
+	core.AssertEqual[slog.Logger](t, mockLog, result, "original logger")
 }
 
 func TestWithComponent(t *testing.T) {
@@ -90,17 +90,17 @@ func TestWithComponent(t *testing.T) {
 	component := ComponentServer
 
 	result := WithComponent(mockLog, component)
-	core.AssertNotNil(t, result, "should return a logger")
+	core.AssertNotNil(t, result, "logger")
 
 	if ml, ok := result.(*testutils.MockFieldLogger); ok {
 		if comp, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields, FieldComponent, "component"); ok {
-			core.AssertEqual(t, ComponentServer, comp, "should have component field")
+			core.AssertEqual(t, ComponentServer, comp, "component")
 		}
 	}
 
 	// Test with nil logger
 	result = WithComponent(nil, component)
-	core.AssertNil(t, result, "should return nil for nil logger")
+	core.AssertNil(t, result, "nil logger result")
 }
 
 func TestWithSessionID(t *testing.T) {
@@ -108,11 +108,11 @@ func TestWithSessionID(t *testing.T) {
 	sessionID := "session-123"
 
 	result := WithSessionID(mockLog, sessionID)
-	core.AssertNotNil(t, result, "should return a logger")
+	core.AssertNotNil(t, result, "logger")
 
 	if ml, ok := result.(*testutils.MockFieldLogger); ok {
 		if sid, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields, FieldSessionID, "session_id"); ok {
-			core.AssertEqual(t, "session-123", sid, "should have session ID")
+			core.AssertEqual(t, "session-123", sid, "session_id")
 		}
 	}
 }
@@ -122,19 +122,19 @@ func TestWithError(t *testing.T) {
 	testErr := errors.New("test error")
 
 	result := WithError(mockLog, testErr)
-	core.AssertNotNil(t, result, "should return a logger")
+	core.AssertNotNil(t, result, "logger")
 
 	if ml, ok := result.(*testutils.MockFieldLogger); ok {
 		if err, ok := testutils.AssertFieldTypeIs[error](t, ml.Fields, FieldError, "error"); ok {
-			core.AssertEqual(t, testErr, err, "should have error field")
+			core.AssertEqual(t, testErr, err, "error")
 		}
 	}
 
 	// Test with nil error
 	result = WithError(mockLog, nil)
-	core.AssertEqual[slog.Logger](t, mockLog, result, "should return original logger for nil error")
+	core.AssertEqual[slog.Logger](t, mockLog, result, "original logger")
 
 	// Test with nil logger
 	result = WithError(nil, testErr)
-	core.AssertNil(t, result, "should return nil for nil logger")
+	core.AssertNil(t, result, "nil logger result")
 }

--- a/pkg/nanorpc/utils/fields_test.go
+++ b/pkg/nanorpc/utils/fields_test.go
@@ -28,10 +28,8 @@ func TestWithRemoteAddr(t *testing.T) {
 	core.AssertNotNil(t, result, "should return a logger")
 
 	if ml, ok := result.(*testutils.MockFieldLogger); ok {
-		if remoteAddr, ok := testutils.GetField[string, string](ml.Fields, FieldRemoteAddr); ok {
+		if remoteAddr, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields, FieldRemoteAddr, "remote_addr"); ok {
 			core.AssertEqual(t, "127.0.0.1:8080", remoteAddr, "should have remote address")
-		} else {
-			t.Error("logger should have remote_addr field")
 		}
 	}
 
@@ -52,10 +50,8 @@ func TestWithLocalAddr(t *testing.T) {
 	core.AssertNotNil(t, result, "should return a logger")
 
 	if ml, ok := result.(*testutils.MockFieldLogger); ok {
-		if localAddr, ok := testutils.GetField[string, string](ml.Fields, FieldLocalAddr); ok {
+		if localAddr, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields, FieldLocalAddr, "local_addr"); ok {
 			core.AssertEqual(t, "192.168.1.1:9090", localAddr, "should have local address")
-		} else {
-			t.Error("logger should have local_addr field")
 		}
 	}
 }
@@ -74,17 +70,13 @@ func TestWithConnAddrs(t *testing.T) {
 
 	if ml, ok := result.(*testutils.MockFieldLogger); ok {
 		// Check remote address
-		if remoteAddr, ok := testutils.GetField[string, string](ml.Fields, FieldRemoteAddr); ok {
+		if remoteAddr, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields, FieldRemoteAddr, "remote_addr"); ok {
 			core.AssertEqual(t, "192.168.1.1:9090", remoteAddr, "should have remote address")
-		} else {
-			t.Error("logger should have remote_addr field")
 		}
 
 		// Check local address
-		if localAddr, ok := testutils.GetField[string, string](ml.Fields, FieldLocalAddr); ok {
+		if localAddr, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields, FieldLocalAddr, "local_addr"); ok {
 			core.AssertEqual(t, "127.0.0.1:8080", localAddr, "should have local address")
-		} else {
-			t.Error("logger should have local_addr field")
 		}
 	}
 
@@ -101,10 +93,8 @@ func TestWithComponent(t *testing.T) {
 	core.AssertNotNil(t, result, "should return a logger")
 
 	if ml, ok := result.(*testutils.MockFieldLogger); ok {
-		if comp, ok := testutils.GetField[string, string](ml.Fields, FieldComponent); ok {
+		if comp, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields, FieldComponent, "component"); ok {
 			core.AssertEqual(t, ComponentServer, comp, "should have component field")
-		} else {
-			t.Error("logger should have component field")
 		}
 	}
 
@@ -121,10 +111,8 @@ func TestWithSessionID(t *testing.T) {
 	core.AssertNotNil(t, result, "should return a logger")
 
 	if ml, ok := result.(*testutils.MockFieldLogger); ok {
-		if sid, ok := testutils.GetField[string, string](ml.Fields, FieldSessionID); ok {
+		if sid, ok := testutils.AssertFieldTypeIs[string](t, ml.Fields, FieldSessionID, "session_id"); ok {
 			core.AssertEqual(t, "session-123", sid, "should have session ID")
-		} else {
-			t.Error("logger should have session_id field")
 		}
 	}
 }
@@ -137,10 +125,8 @@ func TestWithError(t *testing.T) {
 	core.AssertNotNil(t, result, "should return a logger")
 
 	if ml, ok := result.(*testutils.MockFieldLogger); ok {
-		if err, ok := testutils.GetField[string, error](ml.Fields, FieldError); ok {
+		if err, ok := testutils.AssertFieldTypeIs[error](t, ml.Fields, FieldError, "error"); ok {
 			core.AssertEqual(t, testErr, err, "should have error field")
-		} else {
-			t.Error("logger should have error field")
 		}
 	}
 

--- a/pkg/nanorpc/utils/slices_test.go
+++ b/pkg/nanorpc/utils/slices_test.go
@@ -32,18 +32,18 @@ func testClearSlicePrimitives(t *testing.T) {
 	result := ClearSlice(ints)
 
 	// Verify length is 0 but capacity unchanged
-	core.AssertEqual(t, 0, len(result), "length should be 0")
-	core.AssertEqual(t, originalCap, cap(result), "capacity should be unchanged")
+	core.AssertEqual(t, 0, len(result), "length")
+	core.AssertEqual(t, originalCap, cap(result), "capacity")
 
 	// Verify same underlying array
 	if len(result) > 0 {
 		resultArrayPtr := unsafe.Pointer(&result[0])
-		core.AssertEqual(t, originalArrayPtr, resultArrayPtr, "should reuse same array")
+		core.AssertEqual(t, originalArrayPtr, resultArrayPtr, "array pointer")
 	}
 
 	// Verify original slice elements are zeroed
 	for i := 0; i < len(ints); i++ {
-		core.AssertEqual(t, 0, ints[i], "element should be zeroed")
+		core.AssertEqual(t, 0, ints[i], "element %d", i)
 	}
 }
 
@@ -53,12 +53,12 @@ func testClearSliceStrings(t *testing.T) {
 
 	result := ClearSlice(strings)
 
-	core.AssertEqual(t, 0, len(result), "length should be 0")
-	core.AssertEqual(t, originalCap, cap(result), "capacity should be unchanged")
+	core.AssertEqual(t, 0, len(result), "length")
+	core.AssertEqual(t, originalCap, cap(result), "capacity")
 
 	// Verify original slice elements are zeroed
 	for i := 0; i < len(strings); i++ {
-		core.AssertEqual(t, "", strings[i], "string should be empty")
+		core.AssertEqual(t, "", strings[i], "string %d", i)
 	}
 }
 
@@ -72,15 +72,15 @@ func testClearSliceStructs(t *testing.T) {
 
 	result := ClearSlice(structs)
 
-	core.AssertEqual(t, 0, len(result), "length should be 0")
-	core.AssertEqual(t, originalCap, cap(result), "capacity should be unchanged")
+	core.AssertEqual(t, 0, len(result), "length")
+	core.AssertEqual(t, originalCap, cap(result), "capacity")
 
 	// Verify all fields are zeroed
 	for i := 0; i < len(structs); i++ {
-		core.AssertEqual(t, 0, structs[i].ID, "ID should be zero")
-		core.AssertEqual(t, "", structs[i].Name, "Name should be empty")
-		core.AssertNil(t, structs[i].Data, "Data should be nil")
-		core.AssertNil(t, structs[i].Ptr, "Ptr should be nil")
+		core.AssertEqual(t, 0, structs[i].ID, "ID %d", i)
+		core.AssertEqual(t, "", structs[i].Name, "Name %d", i)
+		core.AssertNil(t, structs[i].Data, "Data %d", i)
+		core.AssertNil(t, structs[i].Ptr, "Ptr %d", i)
 	}
 }
 
@@ -88,15 +88,15 @@ func testClearSliceEmpty(t *testing.T) {
 	empty := []int{}
 	result := ClearSlice(empty)
 
-	core.AssertEqual(t, 0, len(result), "length should be 0")
-	core.AssertEqual(t, 0, cap(result), "capacity should be 0")
+	core.AssertEqual(t, 0, len(result), "length")
+	core.AssertEqual(t, 0, cap(result), "capacity")
 }
 
 func testClearSliceNil(t *testing.T) {
 	var nilSlice []int
 	result := ClearSlice(nilSlice)
 
-	core.AssertNil(t, result, "result should be nil")
+	core.AssertNil(t, result, "result")
 }
 
 func testClearSliceCapacity(t *testing.T) {
@@ -106,13 +106,13 @@ func testClearSliceCapacity(t *testing.T) {
 
 	result := ClearSlice(slice)
 
-	core.AssertEqual(t, 0, len(result), "length should be 0")
-	core.AssertEqual(t, 10, cap(result), "capacity should be preserved")
+	core.AssertEqual(t, 0, len(result), "length")
+	core.AssertEqual(t, 10, cap(result), "capacity")
 
 	// Can reuse the slice
 	result = append(result, 10, 20, 30, 40, 50)
-	core.AssertEqual(t, 5, len(result), "should be able to append")
-	core.AssertEqual(t, 10, cap(result), "capacity still unchanged")
+	core.AssertEqual(t, 5, len(result), "length after append")
+	core.AssertEqual(t, 10, cap(result), "capacity after append")
 }
 
 func TestClearAndNilSlice(t *testing.T) {
@@ -129,11 +129,11 @@ func testClearAndNilPrimitives(t *testing.T) {
 	result := ClearAndNilSlice(ints)
 
 	// Result should be nil
-	core.AssertNil(t, result, "result should be nil")
+	core.AssertNil(t, result, "result")
 
 	// Original slice should have zeroed elements
 	for i := 0; i < len(ints); i++ {
-		core.AssertEqual(t, 0, ints[i], "element should be zeroed")
+		core.AssertEqual(t, 0, ints[i], "element %d", i)
 	}
 }
 
@@ -146,18 +146,18 @@ func testClearAndNilStructs(t *testing.T) {
 	result := ClearAndNilSlice(structs)
 
 	// Result should be nil
-	core.AssertNil(t, result, "result should be nil")
+	core.AssertNil(t, result, "result")
 
 	// Original struct should be zeroed
-	core.AssertEqual(t, 0, structs[0].ID, "ID should be zero")
-	core.AssertEqual(t, "", structs[0].Name, "Name should be empty")
-	core.AssertNil(t, structs[0].Data, "Data should be nil")
-	core.AssertNil(t, structs[0].Ptr, "Ptr should be nil")
+	core.AssertEqual(t, 0, structs[0].ID, "ID")
+	core.AssertEqual(t, "", structs[0].Name, "Name")
+	core.AssertNil(t, structs[0].Data, "Data")
+	core.AssertNil(t, structs[0].Ptr, "Ptr")
 }
 
 func testClearAndNilNil(t *testing.T) {
 	var nilSlice []int
 	result := ClearAndNilSlice(nilSlice)
 
-	core.AssertNil(t, result, "result should be nil")
+	core.AssertNil(t, result, "result")
 }

--- a/pkg/nanorpc/utils/testutils/helpers.go
+++ b/pkg/nanorpc/utils/testutils/helpers.go
@@ -124,19 +124,39 @@ func AssertWaitForCondition(t core.T, condition func() bool, timeout time.Durati
 	return ok
 }
 
+// AssertField asserts that a field exists in a map.
+func AssertField(t core.T, m map[string]any, field, name string, args ...any) (any, bool) {
+	t.Helper()
+	v, ok := m[field]
+	if !ok {
+		doError(t, name, args, "field %q not found", field)
+	}
+	return v, ok
+}
+
+// AssertNotField asserts that a field does not exist in a map.
+func AssertNotField(t core.T, m map[string]any, field, name string, args ...any) bool {
+	t.Helper()
+	if v, ok := m[field]; ok {
+		doError(t, name, args, "field %q should not exist, got %v", field, v)
+		return false
+	}
+	return true
+}
+
 // AssertFieldTypeIs asserts that a field in a map has the expected type.
 func AssertFieldTypeIs[T any](t core.T, m map[string]any, field, name string, args ...any) (T, bool) {
 	t.Helper()
-	vi, ok := m[field]
+	var zero T
+
+	vi, ok := AssertField(t, m, field, name, args...)
 	if !ok {
-		var zero T
-		doError(t, name, args, "field %q not found", field)
 		return zero, false
 	}
 
 	v, ok := vi.(T)
 	if !ok {
-		doError(t, name, args, "field %q type %T, expected %T", field, vi, v)
+		doError(t, name, args, "field %q type %T, expected %T", field, vi, zero)
 	}
 
 	return v, ok

--- a/pkg/nanorpc/utils/testutils/helpers.go
+++ b/pkg/nanorpc/utils/testutils/helpers.go
@@ -123,3 +123,33 @@ func AssertWaitForCondition(t core.T, condition func() bool, timeout time.Durati
 	}
 	return ok
 }
+
+// AssertFieldTypeIs asserts that a field in a map has the expected type.
+func AssertFieldTypeIs[T any](t core.T, m map[string]any, field, name string, args ...any) (T, bool) {
+	t.Helper()
+	vi, ok := m[field]
+	if !ok {
+		var zero T
+		doError(t, name, args, "field %q not found", field)
+		return zero, false
+	}
+
+	v, ok := vi.(T)
+	if !ok {
+		doError(t, name, args, "field %q type %T, expected %T", field, vi, v)
+	}
+
+	return v, ok
+}
+
+func doError(t core.T, prefixFormat string, prefixArgs []any, messageFormat string, messageArgs ...any) {
+	var prefix, msg string
+	if prefixFormat != "" {
+		prefix = fmt.Sprintf(prefixFormat, prefixArgs...)
+	}
+	msg = fmt.Sprintf(messageFormat, messageArgs...)
+	if prefix != "" {
+		msg = prefix + ": " + msg
+	}
+	t.Error(msg)
+}

--- a/pkg/nanorpc/utils/testutils/helpers_test.go
+++ b/pkg/nanorpc/utils/testutils/helpers_test.go
@@ -386,9 +386,9 @@ func (tc assertWaitForConditionTestCase) Test(t *testing.T) {
 	core.AssertEqual(t, tc.expectSuccess, result, "assertion result")
 
 	if tc.expectSuccess {
-		core.AssertFalse(t, mock.HasErrors(), "should not have errors on success")
+		core.AssertFalse(t, mock.HasErrors(), "errors on success")
 	} else {
-		core.AssertTrue(t, mock.HasErrors(), "should have errors on failure")
+		core.AssertTrue(t, mock.HasErrors(), "errors on failure")
 	}
 }
 
@@ -441,13 +441,13 @@ func (tc assertWaitForConditionErrorMessageTestCase) Test(t *testing.T) {
 	// Test with formatted name
 	AssertWaitForCondition(mock, falseCondition, tc.timeout, "operation %s", "test")
 
-	core.AssertTrue(t, mock.HasErrors(), "should have error")
+	core.AssertTrue(t, mock.HasErrors(), "error")
 	errs := mock.Errors
-	core.AssertTrue(t, len(errs) > 0, "should have error messages")
+	core.AssertTrue(t, len(errs) > 0, "error messages")
 
 	errorMsg := errs[0]
-	core.AssertContains(t, errorMsg, tc.expectedPrefixContent, "should contain formatted prefix")
-	core.AssertContains(t, errorMsg, tc.expectedTimeoutContent, "should contain timeout message")
+	core.AssertContains(t, errorMsg, tc.expectedPrefixContent, "formatted prefix")
+	core.AssertContains(t, errorMsg, tc.expectedTimeoutContent, "timeout message")
 }
 
 // Factory function for assertWaitForConditionErrorMessageTestCase
@@ -494,13 +494,13 @@ func (tc assertWaitForConditionEmptyNameTestCase) Test(t *testing.T) {
 	// Test with empty name
 	AssertWaitForCondition(mock, falseCondition, tc.timeout, "")
 
-	core.AssertTrue(t, mock.HasErrors(), "should have error")
+	core.AssertTrue(t, mock.HasErrors(), "error")
 	errs := mock.Errors
-	core.AssertTrue(t, len(errs) > 0, "should have error messages")
+	core.AssertTrue(t, len(errs) > 0, "error messages")
 
 	errorMsg := errs[0]
-	core.AssertContains(t, errorMsg, tc.expectedTimeoutContent, "should contain timeout message")
-	core.AssertFalse(t, strings.Contains(errorMsg, tc.excludedContent), "should not have colon prefix")
+	core.AssertContains(t, errorMsg, tc.expectedTimeoutContent, "timeout message")
+	core.AssertFalse(t, strings.Contains(errorMsg, tc.excludedContent), "colon prefix excluded")
 }
 
 // Factory function for assertWaitForConditionEmptyNameTestCase
@@ -558,7 +558,7 @@ func (tc assertFieldTypeIsTestCase) Test(t *testing.T) {
 
 func (tc assertFieldTypeIsTestCase) validateSuccessCase(t *testing.T, mock *core.MockT, result string) {
 	t.Helper()
-	core.AssertFalse(t, mock.HasErrors(), "should not have errors on success")
+	core.AssertFalse(t, mock.HasErrors(), "errors on success")
 	if expectedStr, ok := tc.expected.(string); ok {
 		core.AssertEqual(t, expectedStr, result, "field value")
 	}
@@ -566,7 +566,7 @@ func (tc assertFieldTypeIsTestCase) validateSuccessCase(t *testing.T, mock *core
 
 func (tc assertFieldTypeIsTestCase) validateFailureCase(t *testing.T, mock *core.MockT) {
 	t.Helper()
-	core.AssertTrue(t, mock.HasErrors(), "should have errors on failure")
+	core.AssertTrue(t, mock.HasErrors(), "errors on failure")
 	tc.validateErrorMessage(t, mock)
 }
 
@@ -580,7 +580,7 @@ func (tc assertFieldTypeIsTestCase) validateErrorMessage(t *testing.T, mock *cor
 	if _, exists := tc.input[tc.field]; !exists {
 		core.AssertContains(t, errorMsg, "not found", "missing field error")
 	} else {
-		core.AssertContains(t, errorMsg, "type", "type mismatch error")
+		core.AssertContains(t, errorMsg, "type", "type error")
 	}
 }
 
@@ -696,10 +696,10 @@ func (tc assertFieldTestCase) Test(t *testing.T) {
 	core.AssertEqual(t, tc.wantOK, ok, "field assertion")
 
 	if tc.wantOK {
-		core.AssertFalse(t, mock.HasErrors(), "should not have errors on success")
+		core.AssertFalse(t, mock.HasErrors(), "errors on success")
 		core.AssertEqual(t, tc.expected, result, "field value")
 	} else {
-		core.AssertTrue(t, mock.HasErrors(), "should have errors on failure")
+		core.AssertTrue(t, mock.HasErrors(), "errors on failure")
 		if len(mock.Errors) > 0 {
 			errorMsg := mock.Errors[0]
 			core.AssertContains(t, errorMsg, "not found", "missing field error")
@@ -766,12 +766,12 @@ func (tc assertNotFieldTestCase) Test(t *testing.T) {
 	core.AssertEqual(t, tc.wantOK, ok, "not field assertion")
 
 	if tc.wantOK {
-		core.AssertFalse(t, mock.HasErrors(), "should not have errors on success")
+		core.AssertFalse(t, mock.HasErrors(), "errors on success")
 	} else {
-		core.AssertTrue(t, mock.HasErrors(), "should have errors on failure")
+		core.AssertTrue(t, mock.HasErrors(), "errors on failure")
 		if len(mock.Errors) > 0 {
 			errorMsg := mock.Errors[0]
-			core.AssertContains(t, errorMsg, "should not exist", "field exists error")
+			core.AssertContains(t, errorMsg, "should not exist", "field exists")
 			core.AssertContains(t, errorMsg, "got", "error shows value")
 		}
 	}

--- a/pkg/nanorpc/utils/testutils/mockconn_test.go
+++ b/pkg/nanorpc/utils/testutils/mockconn_test.go
@@ -18,22 +18,22 @@ func TestMockConn_Read(t *testing.T) {
 	buf := make([]byte, 5)
 	n, err := conn.Read(buf)
 	core.AssertNoError(t, err, "Read should not fail")
-	core.AssertEqual(t, 5, n, "should read 5 bytes")
-	core.AssertEqual(t, "hello", string(buf), "should read correct data")
+	core.AssertEqual(t, 5, n, "bytes read")
+	core.AssertEqual(t, "hello", string(buf), "data")
 	core.AssertEqual(t, 5, conn.ReadPos, "ReadPos should advance")
 
 	// Test reading remaining data
 	buf = make([]byte, 10)
 	n, err = conn.Read(buf)
 	core.AssertNoError(t, err, "Read should not fail")
-	core.AssertEqual(t, 6, n, "should read remaining 6 bytes")
-	core.AssertEqual(t, " world", string(buf[:n]), "should read remaining data")
+	core.AssertEqual(t, 6, n, "remaining bytes")
+	core.AssertEqual(t, " world", string(buf[:n]), "remaining data")
 	core.AssertEqual(t, 11, conn.ReadPos, "ReadPos should be at end")
 
 	// Test EOF behaviour
 	n, err = conn.Read(buf)
 	core.AssertNoError(t, err, "Read at EOF should not error")
-	core.AssertEqual(t, 0, n, "should read 0 bytes at EOF")
+	core.AssertEqual(t, 0, n, "EOF bytes")
 }
 
 // TestMockConn_ReadClosed tests reading from closed connection
@@ -45,9 +45,9 @@ func TestMockConn_ReadClosed(t *testing.T) {
 
 	buf := make([]byte, 4)
 	n, err := conn.Read(buf)
-	core.AssertEqual(t, 0, n, "should read 0 bytes from closed conn")
-	core.AssertError(t, err, "should return error for closed conn")
-	core.AssertEqual(t, net.ErrClosed, err, "should return net.ErrClosed")
+	core.AssertEqual(t, 0, n, "closed conn bytes")
+	core.AssertError(t, err, "closed conn error")
+	core.AssertEqual(t, net.ErrClosed, err, "error type")
 }
 
 // TestMockConn_Write tests the Write method
@@ -58,14 +58,14 @@ func TestMockConn_Write(t *testing.T) {
 	data1 := []byte("hello")
 	n, err := conn.Write(data1)
 	core.AssertNoError(t, err, "Write should not fail")
-	core.AssertEqual(t, 5, n, "should write 5 bytes")
+	core.AssertEqual(t, 5, n, "bytes written")
 	core.AssertSliceEqual(t, []byte("hello"), conn.WriteData, "WriteData should contain written data")
 
 	// Test second write (should append)
 	data2 := []byte(" world")
 	n, err = conn.Write(data2)
 	core.AssertNoError(t, err, "Write should not fail")
-	core.AssertEqual(t, 6, n, "should write 6 bytes")
+	core.AssertEqual(t, 6, n, "bytes written")
 	core.AssertSliceEqual(t, []byte("hello world"), conn.WriteData, "WriteData should contain all written data")
 }
 
@@ -77,9 +77,9 @@ func TestMockConn_WriteClosed(t *testing.T) {
 
 	data := []byte("test")
 	n, err := conn.Write(data)
-	core.AssertEqual(t, 0, n, "should write 0 bytes to closed conn")
-	core.AssertError(t, err, "should return error for closed conn")
-	core.AssertEqual(t, net.ErrClosed, err, "should return net.ErrClosed")
+	core.AssertEqual(t, 0, n, "closed conn bytes")
+	core.AssertError(t, err, "closed conn error")
+	core.AssertEqual(t, net.ErrClosed, err, "error type")
 }
 
 // TestMockConn_Close tests the Close method
@@ -156,7 +156,7 @@ func TestMockConn_ReadWriteIntegration(t *testing.T) {
 	writeData := []byte("integration test data")
 	n, err := conn.Write(writeData)
 	core.AssertNoError(t, err, "Write should not fail")
-	core.AssertEqual(t, len(writeData), n, "should write all data")
+	core.AssertEqual(t, len(writeData), n, "all data written")
 
 	// Verify written data is in WriteData buffer
 	core.AssertSliceEqual(t, writeData, conn.WriteData, "WriteData should contain written data")
@@ -169,8 +169,8 @@ func TestMockConn_ReadWriteIntegration(t *testing.T) {
 	readBuf := make([]byte, 14)
 	n, err = conn.Read(readBuf)
 	core.AssertNoError(t, err, "Read should not fail")
-	core.AssertEqual(t, 14, n, "should read 14 bytes")
-	core.AssertEqual(t, "read test data", string(readBuf), "should read correct data")
+	core.AssertEqual(t, 14, n, "bytes read")
+	core.AssertEqual(t, "read test data", string(readBuf), "data")
 
 	// Verify read and write operations are independent
 	core.AssertSliceEqual(t, writeData, conn.WriteData, "WriteData should be unchanged by read")


### PR DESCRIPTION
# NanoRPC Test Assertion Refactoring and Standardisation

## Summary

This pull request implements comprehensive test assertion refactoring across
the entire NanoRPC codebase, introducing new type-safe assertion utilities and
standardising all test assertion patterns to follow strict darvaza.org testing
guidelines.

## Motivation

The NanoRPC test suite contained 325+ instances of verbose assertion
descriptions and manual error-checking patterns that violated darvaza.org
testing guidelines. These patterns created maintenance overhead, inconsistent
error messages, and potential safety issues from direct map access.

## Changes Made

### Phase 1: New Test Infrastructure

- **Added `AssertFieldTypeIs[T]` generic assertion function** for type-safe
  field validation.
- **Created comprehensive field assertion helpers** (`AssertField`,
  `AssertNotField`, `AssertFieldTypeIs`).
- **Implemented full test coverage** for new utilities (287 test lines).

### Phase 2: Safety Improvements

- **Eliminated direct map access patterns** that could cause runtime panics.
- **Replaced manual `testutils.GetField` patterns** with safer assertion
  helpers.
- **Added proper error handling** with structured assertions.

### Phase 3: Comprehensive Standardisation

- **Converted 325+ verbose assertion descriptions** to concise prefixes.
- **Standardised error condition testing** across protocol tests.
- **Replaced manual `t.Errorf` patterns** with proper `core.Assert*` functions.

## Key Improvements

### Before and After Examples

#### Verbose Assertions (Before)

```go
core.AssertEqual(t, expected, actual, "should return expected value")
core.AssertNotNil(t, result, "should return a logger")
core.AssertError(t, err, "Hash should not error for path %s", path)
```

#### Concise Prefixes (After)

```go
core.AssertEqual(t, expected, actual, "value")
core.AssertNotNil(t, result, "logger")
core.AssertError(t, err, "hash for path %s", path)
```

#### Manual Error Checking (Before)

```go
if fieldValue, ok := testutils.GetField[string, string](ml.Fields,
    "field_name"); ok {
    core.AssertEqual(t, expected, fieldValue, "description")
} else {
    t.Error("logger should have field_name field")
}
```

#### Type-Safe Assertions (After)

```go
if fieldValue, ok := AssertFieldTypeIs[string](t, ml.Fields,
    "field_name", "field_name"); ok {
    core.AssertEqual(t, expected, fieldValue, "description")
}
```

## Files Modified

### Generator Package (1 file)

- `generator_test.go`: 5 assertion improvements

### NanoRPC Package (18 files)

#### Client Package

- `config_test.go`: 42 assertion standardisations
- `logger_test.go`: 42 assertion improvements
- `request_counter_test.go`: 8 assertion updates
- `request_test.go`: 3 assertion fixes

#### Server Package

- `handler_test.go`: 27 assertion improvements
- `logger_test.go`: 24 assertion updates
- `request_context_test.go`: 8 manual patterns → core assertions
- `subscription_test.go`: 60+ assertion standardisations

#### Core Package

- `hashcache_test.go`: 49 assertion improvements
- `nanorpc_protocol_test.go`: Error condition standardisation
- `nanorpc_test.go`: 1 assertion fix
- `testutils_test.go`: 1 assertion improvement

#### Utils Package

- `fields_test.go`: 12 assertion updates
- `slices_test.go`: 28 assertion improvements
- `testutils/helpers.go`: **NEW** - 50 lines of assertion utilities
- `testutils/helpers_test.go`: **EXPANDED** - 287 additional test lines
- `testutils/mockconn_test.go`: 14 assertion improvements
- `testutils/mockfieldlogger_test.go`: 7 assertion updates + safety fixes

## Benefits

### Code Quality

- **Consistent assertion patterns** across entire test suite
- **Improved readability** with standardised 'prefix: value' format
- **Enhanced maintainability** with reduced cognitive load

### Safety

- **Eliminated runtime panic risks** from unchecked map operations
- **Type-safe field assertions** with proper error handling
- **Structured error reporting** with consistent patterns

### Developer Experience

- **Better test failure messages** with clear context
- **Standardised testing utilities** for future development
- **Complete darvaza.org guidelines compliance**

## Testing

- **All tests pass**: `make test-nanorpc` successful
- **Full coverage maintained**: `make all coverage` successful
- **No regressions introduced**: Semantic equivalence preserved
- **Lint compliance**: All markdownlint and cSpell checks pass

## Statistics

- **Files changed**: 19 total
- **Lines added**: +766 (primarily new test utilities)
- **Lines removed**: -489 (verbose patterns eliminated)
- **Net improvement**: +277 lines with enhanced functionality
- **Assertions standardised**: 325+ instances across codebase

## Commit History

1. `feat(testutils): add AssertFieldTypeIs generic assertion function`
2. `feat(testutils): add composable field assertion helpers`
3. `refactor(tests): replace GetField patterns with AssertFieldTypeIs`
4. `refactor(tests): standardise error condition testing in protocol tests`
5. `refactor(tests): standardise assertion name prefixes in generator tests`
6. `refactor(tests): complete assertion hygiene standardisation across nanorpc`

## Risk Assessment

**Risk Level**: Low

- **Semantic preservation**: All changes maintain identical test logic
- **Incremental validation**: Each phase tested independently
- **Comprehensive coverage**: No functionality changes, only improvements
- **Full test verification**: Complete test suite passes successfully

This refactoring significantly improves code quality, maintainability, and
developer experience whilst maintaining full backwards compatibility and test
coverage.
