### PR TITLE
chore(deps): add renovate package rules and go version constraints

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,21 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": ["golang-version"],
+      "allowedVersions": "1.23"
+    },
+    {
+      "groupName": "Darvaza Projects",
+      "groupSlug": "darvaza",
+      "matchPackageNames": [
+        "darvaza.org/**"
+      ]
+    }
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
   ]
 }


### PR DESCRIPTION
- Pin Go updates to version 1.23 only via allowedVersions.
- Group Darvaza packages (darvaza.org/**) for coordinated updates.
- Enable automatic go mod tidy after dependency updates.